### PR TITLE
docs(design): revise design docs for pipekit, geostack, plumax integration

### DIFF
--- a/docs/design_docs/README.md
+++ b/docs/design_docs/README.md
@@ -25,10 +25,17 @@ filterX/
 │   ├── filters.md         # Sequential EnKF variants (ETKF, LETKF, EnSRF, ESTKF, etc.)
 │   ├── processes.md       # EKP algorithms (EKI, EKS, UKI, GNKI, SparseEKI, TEKI)
 │   ├── smoothers.md       # Ensemble smoothers (EnKS, RTS, fixed-lag, IES)
-│   ├── localization_inflation.md  # Localization tapers + inflation strategies
+│   ├── localization_inflation.md  # Localization tapers + inflation strategies (incl. GeoLocalizer)
 │   ├── diagnostics.md     # DA evaluation metrics (rank histogram, Desroziers, CRPS, etc.)
 │   ├── differentiable_da.md      # Deep dive: backprop through filters
-│   └── optax_ekp.md       # Deep dive: EKP as optax GradientTransformations
+│   ├── optax_ekp.md       # Deep dive: EKP as optax GradientTransformations
+│   ├── multi_instrument.md       # JointObsOperator + SequentialAssimilation (D12)
+│   └── state_persistence.md      # Serialization contract + warm-start patterns (D15)
+├── integrations/
+│   ├── README.md          # Index and reading order for ecosystem integration docs
+│   ├── pipekit.md         # Structural Protocol satisfaction with pipekit-cycle (D11)
+│   ├── plumax.md          # Multi-instrument methane attribution recipe (Tier IV)
+│   └── geostack.md        # CarrierAdapter for coordax / GeoTensor particles (D13)
 ├── examples/
 │   ├── README.md          # Index and reading order
 │   ├── primitives.md      # Layer 0 usage patterns
@@ -38,8 +45,9 @@ filterX/
 ├── research/
 │   ├── README.md          # Index for research docs
 │   ├── research_enskf.md  # Audit of existing kalman_filter/ code (~5,000 lines)
-│   └── ens_kalman_process.md  # EKP theory: math, process zoo, BLR connection
-└── decisions.md           # 10 ADRs (D1–D10)
+│   ├── ens_kalman_process.md  # EKP theory: math, process zoo, BLR connection
+│   └── operational_da.md  # Streaming / alert-service patterns
+└── decisions.md           # 16 ADRs (D1–D16)
 ```
 
 ## Reading Order
@@ -52,6 +60,8 @@ filterX/
 6. **[features/filters.md](features/filters.md)** → **[processes.md](features/processes.md)** → **[smoothers.md](features/smoothers.md)** — algorithm deep dives
 7. **[features/localization_inflation.md](features/localization_inflation.md)** → **[diagnostics.md](features/diagnostics.md)** — tuning and evaluation
 8. **[features/differentiable_da.md](features/differentiable_da.md)** → **[optax_ekp.md](features/optax_ekp.md)** — unique capabilities
-9. **[examples/primitives.md](examples/primitives.md)** → **[components.md](examples/components.md)** → **[models.md](examples/models.md)** → **[integration.md](examples/integration.md)** — see it in action
-10. **[decisions.md](decisions.md)** — understand the tradeoffs (D1–D10)
-11. **[research/](research/)** — background theory and code audits
+9. **[features/multi_instrument.md](features/multi_instrument.md)** → **[features/state_persistence.md](features/state_persistence.md)** — operational extensions
+10. **[examples/primitives.md](examples/primitives.md)** → **[components.md](examples/components.md)** → **[models.md](examples/models.md)** → **[integration.md](examples/integration.md)** — see it in action
+11. **[integrations/pipekit.md](integrations/pipekit.md)** → **[integrations/plumax.md](integrations/plumax.md)** → **[integrations/geostack.md](integrations/geostack.md)** — ecosystem integration recipes
+12. **[decisions.md](decisions.md)** — understand the tradeoffs (D1–D16)
+13. **[research/](research/)** — background theory, code audits, operational DA

--- a/docs/design_docs/architecture.md
+++ b/docs/design_docs/architecture.md
@@ -177,17 +177,17 @@ class AbstractScheduler(eqx.Module):
 
 All protocols are `eqx.Module` subclasses — pytree-compatible, JIT-friendly, serializable.
 
-### Structural compatibility with `pipekit-cycle`
+### Compatibility with `pipekit-cycle`
 
-filterax's protocols are designed so that the concrete filter and operator classes **structurally satisfy** the three Protocols in `pipekit-cycle` (`ForwardModel`, `ObservationOperator`, `AnalysisStep`). filterax does **not import** pipekit. The compatibility is duck-typed:
+filterax's protocols are designed to map cleanly onto the three Protocols in `pipekit-cycle` (`ForwardModel`, `ObservationOperator`, `AnalysisStep`) — but the names and signatures differ where DA-domain conventions diverge from pipekit's generic surface. Bridging is **one line of user code per concept**; filterax does not ship aliases or import pipekit.
 
-| filterax abstract | pipekit-cycle Protocol | Compatibility shape |
+| filterax abstract | pipekit-cycle Protocol | Bridge |
 |---|---|---|
-| `AbstractDynamics.__call__(state, t0, t1)` | `ForwardModel.step(state, dt)` | filterax dynamics expose `step(state, dt) -> state` as an alias when used in pipekit pipelines |
-| `AbstractObsOperator.__call__(state)` | `ObservationOperator.__call__(state)` | Identical surface |
-| `AbstractSequentialFilter.analysis(forecast, obs, obs_op, obs_noise)` | `AnalysisStep.__call__(forecast, obs, *, obs_op, obs_err_cov)` | filterax filters expose `__call__` as a keyword-arg adapter when used in pipekit pipelines |
+| `AbstractDynamics.__call__(state, t0, t1)` | `ForwardModel.step(state, dt)` | User wraps with a `step(state, dt)` method calling `self._dyn(state, 0.0, dt)` |
+| `AbstractObsOperator.__call__(state)` | `ObservationOperator.__call__(state)` | Identical surface — no wrapper needed |
+| `AbstractSequentialFilter.analysis(forecast, obs, obs_op, obs_noise)` | `AnalysisStep.__call__(forecast, obs, *, obs_op, obs_err_cov)` | User wraps with a `__call__(forecast, obs, *, obs_op, obs_err_cov)` method calling `self._filter.analysis(...)` |
 
-See D11 and `integrations/pipekit.md` for the adapter snippets and the rationale.
+The user wrappers are short (under 10 lines each); `@runtime_checkable` makes `isinstance(wrapper, pipekit_cycle.AnalysisStep)` pass at runtime without inheritance. See D11 and `integrations/pipekit.md` §4 for the concrete snippets and rationale.
 
 ---
 
@@ -276,7 +276,7 @@ class CarrierAdapter(eqx.Module):
         ...
 ```
 
-Filters see only `Float[Array, "N_e N_x"]`. The adapter is user-facing convenience; the math layer stays minimal. filterax ships reference adapters for plain dicts of named arrays in core, and a `coordax.Array` adapter under `filterax.integrations` (no `coordax` runtime dependency — imported lazily). See `integrations/geostack.md`.
+Filters see only `Float[Array, "N_e N_x"]`. The adapter is user-facing convenience; the math layer stays minimal. filterax ships **only** the interface plus a `DictAdapter` reference implementation for `dict[str, Array]` schemas (no optional deps). Coordinate-aware adapters (`CoordaxAdapter`, `GeoTensorAdapter`, …) are downstream-owned — they live in the libraries that own those carriers, not in filterax. See `integrations/geostack.md` for the expected adapter shape.
 
 ---
 

--- a/docs/design_docs/architecture.md
+++ b/docs/design_docs/architecture.md
@@ -177,6 +177,18 @@ class AbstractScheduler(eqx.Module):
 
 All protocols are `eqx.Module` subclasses — pytree-compatible, JIT-friendly, serializable.
 
+### Structural compatibility with `pipekit-cycle`
+
+filterax's protocols are designed so that the concrete filter and operator classes **structurally satisfy** the three Protocols in `pipekit-cycle` (`ForwardModel`, `ObservationOperator`, `AnalysisStep`). filterax does **not import** pipekit. The compatibility is duck-typed:
+
+| filterax abstract | pipekit-cycle Protocol | Compatibility shape |
+|---|---|---|
+| `AbstractDynamics.__call__(state, t0, t1)` | `ForwardModel.step(state, dt)` | filterax dynamics expose `step(state, dt) -> state` as an alias when used in pipekit pipelines |
+| `AbstractObsOperator.__call__(state)` | `ObservationOperator.__call__(state)` | Identical surface |
+| `AbstractSequentialFilter.analysis(forecast, obs, obs_op, obs_noise)` | `AnalysisStep.__call__(forecast, obs, *, obs_op, obs_err_cov)` | filterax filters expose `__call__` as a keyword-arg adapter when used in pipekit pipelines |
+
+See D11 and `integrations/pipekit.md` for the adapter snippets and the rationale.
+
 ---
 
 ## Key Data Types
@@ -235,6 +247,51 @@ Design notes:
 - Ensemble dimension is the leading axis (`N_e, N_x`) for natural `eqx.filter_vmap` over members.
 - `log_likelihood` is optional — only computed when needed for differentiable training.
 - Configuration is `eqx.Module` — serializable, pytree-compatible, JIT-friendly.
+- `particles` is a bare JAX array. Coordinate-aware carriers (`coordax.Array`, `GeoTensor`) are
+  handled via a `CarrierAdapter` outside the core type — see D13 and
+  `integrations/geostack.md`.
+- State types are fully `eqx.tree_serialise_leaves`-compatible — see D15 and
+  `features/state_persistence.md` for the persistence contract.
+
+---
+
+## Carrier Adapter Layer
+
+For consumers that want coordinate-aware ensemble particles (CRS, named dimensions, time coordinates) the core types stay JAX-array only; a `CarrierAdapter` flattens to and unflattens from a plain `(N_e, N_x)` array around analysis calls. The interface lives in `filterax.integrations`:
+
+```python
+class CarrierAdapter(eqx.Module):
+    """Round-trip a coordinate-aware carrier to/from FilterState.particles."""
+
+    @abc.abstractmethod
+    def flatten(self, carrier) -> tuple[Float[Array, "N_e N_x"], "CarrierMeta"]:
+        """Project carrier to a (N_e, N_x) array and a static metadata record."""
+        ...
+
+    @abc.abstractmethod
+    def unflatten(
+        self, particles: Float[Array, "N_e N_x"], meta: "CarrierMeta"
+    ) -> Any:
+        """Reconstruct the original carrier from particles + metadata."""
+        ...
+```
+
+Filters see only `Float[Array, "N_e N_x"]`. The adapter is user-facing convenience; the math layer stays minimal. filterax ships reference adapters for plain dicts of named arrays in core, and a `coordax.Array` adapter under `filterax.integrations` (no `coordax` runtime dependency — imported lazily). See `integrations/geostack.md`.
+
+---
+
+## Serialization Contract
+
+Every state and config type is fully `eqx.tree_serialise_leaves`-compatible (D15). filterax exposes two helpers in Wave 4:
+
+```python
+filterax.save_state(path: str | Path, state: FilterState | ProcessState | UKIState) -> None
+filterax.load_state(path: str | Path, like: FilterState | ProcessState | UKIState) -> FilterState | ProcessState | UKIState
+```
+
+These wrap `eqx.tree_serialise_leaves` / `eqx.tree_deserialise_leaves` with a magic-byte header (`b"FAX1"`) so future schema changes are detectable. All static fields on state types must be JSON-serializable scalars; custom classes in static fields are rejected at construction.
+
+See `features/state_persistence.md` for the full contract, warm-start patterns, and the operational-alert recipe.
 
 ---
 

--- a/docs/design_docs/boundaries.md
+++ b/docs/design_docs/boundaries.md
@@ -35,6 +35,10 @@ This document defines what ekalmX owns, what it delegates, and how it interacts 
 | Variational DA (4DVar, 4DVarNet) | **vardax** | Sister library, different DA paradigm |
 | Natural-gradient optimization (BLR) | **optax_bayes** | Sister library |
 | xarray-level DA orchestration | **xr_assimilate** | Consumes ekalmX as compute backend |
+| Operator composition / pipelines / cycles | **pipekit** + **pipekit-cycle** | filterax classes **structurally satisfy** pipekit-cycle Protocols (`ForwardModel`, `ObservationOperator`, `AnalysisStep`). No import (D11). |
+| Geographic catalogs, readers, carriers | **geostack** / **georeader** / **geotoolz** | filterax provides `CarrierAdapter` for coordax / `GeoTensor` particles (D13). |
+| Spatial patcher (sampler + stitcher) | **filterax** L0 (in-house, Wave 2) → **geotoolz.patch** (post-stabilization) | Hybrid migration per D16. |
+| Plumax / methane attribution forward models | **plumax** (external) | Pluggable via `AbstractDynamics`; multi-instrument observation operators composed via `JointObsOperator` / `SequentialAssimilation` (D12). |
 | xarray pre/post-processing | **geo_toolz** | Upstream (preprocess) and downstream (evaluate) |
 | Training / assimilation loops | **user** | Library, not framework |
 | Continuous-time filters (Kalman-Bucy, etc.) | **ekalmX** zoo/ | Reference only, not core API |
@@ -242,15 +246,21 @@ Sister libraries (same level, different paradigm):
 
 3. **xr_assimilate integration depth** — ekalmX is the compute backend, but the API contract between them (how xr_assimilate calls ekalmX, what state/result types cross the boundary) isn't defined yet.
 
-4. **coordax integration** — Should ensemble states use coordax for coordinate-aware arrays? Depends on coordax maturity. Same open question as vardax.
+4. **3D / volumetric support** — How much native 3D support vs treating 3D as multilayer 2D via `eqx.filter_vmap`?
 
-5. **3D / volumetric support** — How much native 3D support vs treating 3D as multilayer 2D via `eqx.filter_vmap`?
+5. **Particle filters** — The zoo has a continuous-time particle filter. Should ekalmX core include discrete particle filters (bootstrap PF, optimal PF), or is that a separate library?
 
-6. **Particle filters** — The zoo has a continuous-time particle filter. Should ekalmX core include discrete particle filters (bootstrap PF, optimal PF), or is that a separate library?
+6. **Ensemble size adaptivity** — Dynamic ensemble resizing during assimilation. Research topic, not immediate.
 
-7. **Ensemble size adaptivity** — Dynamic ensemble resizing during assimilation. Research topic, not immediate.
+## Resolved (see decisions.md)
 
-8. **Package rename** — Directory is currently `filterX`, library will be `ekalmx`. Rename when standalone repo is created.
+- **pipekit-cycle coupling** — Structural Protocol satisfaction, no import. D11.
+- **Multi-instrument fusion** — Both `JointObsOperator` and `SequentialAssimilation`. D12.
+- **coordax / GeoTensor carriers** — Adapter pattern, core stays JAX-array. D13.
+- **Geospatial localization** — Owned by filterax (`GeoLocalizer`). D14.
+- **Filter state persistence** — `eqx.tree_serialise_leaves`-compatible state types, `save_state` / `load_state` helpers. D15.
+- **Patcher** — In-house in Wave 2; migrate to `geotoolz.patch` once stable. D16.
+- **Package rename** — Directory renamed to `filterax`; package shipped as `filterax`.
 
 ---
 

--- a/docs/design_docs/decisions.md
+++ b/docs/design_docs/decisions.md
@@ -217,15 +217,16 @@ filterax filters need to slot into pipekit `Sequential` / `Graph` / `Cycle` pipe
 - (B) Structural — same method names/shapes, no import, satisfies Protocols via duck typing
 - (C) Optional integration module — `filterax.integrations.pipekit` re-declares classes as protocol satisfiers
 
-**Decision:** Option B. filterax abstracts have method signatures that **structurally satisfy** the pipekit-cycle Protocols. filterax does not import pipekit-cycle. pipekit's `@runtime_checkable` makes `isinstance(my_filter, pipekit_cycle.AnalysisStep)` work without any inheritance.
+**Decision:** Option B. filterax abstracts have method **shapes** (argument types, return types) that map cleanly onto the pipekit-cycle Protocols, even though method names diverge where DA-domain conventions warrant it (`analysis` vs `__call__`; `(state, t0, t1)` vs `(state, dt)`). Bridging is a one-line user-side wrapper per concept; filterax does not import pipekit and does not ship the wrappers. `@runtime_checkable` then makes `isinstance(wrapper, pipekit_cycle.AnalysisStep)` pass at runtime without inheritance.
 
 This mirrors pipekit's own rule: algorithm libraries do not import pipekit. The same discipline keeps filterax usable on its own and droppable into pipekit graphs without coupling.
 
 **Consequences:**
-- Method names on filterax abstracts are chosen with pipekit-cycle compatibility in mind (see `integrations/pipekit.md`).
+- Method shapes on filterax abstracts are chosen with pipekit-cycle bridge clarity in mind (see `integrations/pipekit.md`).
+- filterax filters do **not** themselves satisfy `isinstance(filter, pipekit_cycle.AnalysisStep)` — the wrapper does. Wave 5's compatibility test (FLX-55A) asserts `isinstance(FilterAsAnalysisStep(filter), AnalysisStep)`, not the bare filter.
 - Compatibility is tested from outside filterax (in pipekit-cycle's own test suite, or in a downstream integration test repo). filterax has no pipekit imports.
 - Users who want pipekit's `StatefulOperator` wrapping (e.g., to drive a `Cycle`) write a 5-line wrapper in their own code; filterax does not ship the wrapper.
-- If pipekit-cycle's Protocol signatures change, filterax compatibility breaks silently. We accept this risk in exchange for zero coupling.
+- If pipekit-cycle's Protocol signatures change, filterax compatibility may need a one-line wrapper update on the user side. We accept this in exchange for zero coupling.
 
 ---
 
@@ -264,7 +265,7 @@ This mirrors pipekit's own rule: algorithm libraries do not import pipekit. The 
 - (B) PyTree leaves — relax type to allow particles to be any JAX PyTree; primitives gain an internal flatten step
 - (C) Defer
 
-**Decision:** Option A. `FilterState.particles` is `Float[Array, "N_e N_x"]` in the core type. A `CarrierAdapter` (interface, plus reference implementations for `coordax.Array` and `GeoTensor`) lives in `filterax.integrations` and provides:
+**Decision:** Option A. `FilterState.particles` is `Float[Array, "N_e N_x"]` in the core type. A `CarrierAdapter` interface lives in `filterax.integrations`:
 
 ```python
 class CarrierAdapter(eqx.Module):
@@ -272,12 +273,14 @@ class CarrierAdapter(eqx.Module):
     def unflatten(self, particles: Float[Array, "N_e N_x"], meta: CarrierMeta) -> Carrier: ...
 ```
 
+filterax ships **one** reference implementation — `DictAdapter` for `dict[str, Array]` schemas — because it has zero optional dependencies and covers the common mixed-shape state case. Adapters for `coordax.Array`, `GeoTensor`, or other coordinate-aware carriers are **downstream-owned** (geostack, plumax, user code); filterax does not pull `coordax` or `pyproj` for the carrier path.
+
 Filters never see metadata. Adapters are user-facing convenience; the math layer stays minimal.
 
 **Consequences:**
 - Core stays lean, JAX-pure, and free of optional carrier dependencies.
 - Coordinate awareness costs one flatten/unflatten per analysis call — cheap relative to the analysis itself.
-- Downstream libraries (geostack, plumax) ship their own `CarrierAdapter` implementations; filterax ships the interface plus one reference adapter for plain dicts of named arrays.
+- filterax owns the `CarrierAdapter` interface and the `DictAdapter` reference. Coordinate-aware adapters (e.g. `CoordaxAdapter`, `GeoTensorAdapter`) live in the libraries that own those carriers; `integrations/geostack.md` documents the expected shape so downstream authors can build them consistently.
 - Documented in `integrations/geostack.md`.
 
 ---

--- a/docs/design_docs/decisions.md
+++ b/docs/design_docs/decisions.md
@@ -197,3 +197,153 @@ Architecture Decision Records for ekalmX. Each records the context, options cons
 - Existing `enskf_zoo.py` code needs transposition during migration
 - Matrix operations (cross-covariance, Kalman gain) transpose internally where needed
 - Consistent with torchEnKF's convention `(*batch, N_ensem, x_dim)`
+
+---
+
+## D11: pipekit-cycle protocol compatibility — structural only
+
+**Status:** Accepted
+
+**Context:** `pipekit-cycle` defines three `@runtime_checkable` Protocols that overlap with filterax's abstractions:
+
+- `pipekit_cycle.ForwardModel.step(state, dt) -> state` ≈ filterax `AbstractDynamics.__call__(state, t0, t1)`
+- `pipekit_cycle.ObservationOperator.__call__(state) -> obs` + `linearize` ≈ filterax `AbstractObsOperator.__call__`
+- `pipekit_cycle.AnalysisStep.__call__(forecast, obs, *, obs_op, obs_err_cov) -> analysis` ≈ filterax `AbstractSequentialFilter.analysis`
+
+filterax filters need to slot into pipekit `Sequential` / `Graph` / `Cycle` pipelines without forcing pipekit-cycle as a dependency on every filterax user.
+
+**Options:**
+- (A) Inherit — filterax abstracts subclass pipekit-cycle Protocols (requires pipekit import)
+- (B) Structural — same method names/shapes, no import, satisfies Protocols via duck typing
+- (C) Optional integration module — `filterax.integrations.pipekit` re-declares classes as protocol satisfiers
+
+**Decision:** Option B. filterax abstracts have method signatures that **structurally satisfy** the pipekit-cycle Protocols. filterax does not import pipekit-cycle. pipekit's `@runtime_checkable` makes `isinstance(my_filter, pipekit_cycle.AnalysisStep)` work without any inheritance.
+
+This mirrors pipekit's own rule: algorithm libraries do not import pipekit. The same discipline keeps filterax usable on its own and droppable into pipekit graphs without coupling.
+
+**Consequences:**
+- Method names on filterax abstracts are chosen with pipekit-cycle compatibility in mind (see `integrations/pipekit.md`).
+- Compatibility is tested from outside filterax (in pipekit-cycle's own test suite, or in a downstream integration test repo). filterax has no pipekit imports.
+- Users who want pipekit's `StatefulOperator` wrapping (e.g., to drive a `Cycle`) write a 5-line wrapper in their own code; filterax does not ship the wrapper.
+- If pipekit-cycle's Protocol signatures change, filterax compatibility breaks silently. We accept this risk in exchange for zero coupling.
+
+---
+
+## D12: Multi-instrument fusion — both joint and sequential surfaces
+
+**Status:** Accepted
+
+**Context:** The plumax/geostack motivating use case (Tier IV methane attribution) assimilates observations from TROPOMI, EMIT, and GHGSat at different times, native resolutions, and noise characteristics. The original design's `AbstractObsOperator` is single-instrument.
+
+**Options:**
+- (A) Sequential only — user composes single-instrument analyses in a loop
+- (B) Joint only — `JointObsOperator(ops, noise_covs)` combinator wraps a list as one obs operator
+- (C) Both — sequential wrapper for temporally separated independent overpasses, joint combinator for shared-state simultaneous observations
+
+**Decision:** Option C. Ship both:
+
+- `JointObsOperator(ops: tuple[AbstractObsOperator, ...], noise_covs: tuple[AbstractLinearOperator, ...])` — concatenates outputs of each `op(state)` into one stacked observation vector, returns a block-diagonal noise covariance. One analysis call, correct cross-instrument covariance when noise is block-diagonal.
+- `SequentialAssimilation(filter: AbstractSequentialFilter)` — Layer 2 helper that loops over a list of `(obs, obs_op, obs_noise)` tuples, calling `filter.analysis` once per instrument. Used when overpasses are temporally separated and there is no benefit to a joint update.
+
+**Consequences:**
+- `AbstractObsOperator` stays single-instrument; joint behaviour is composition, not a new protocol.
+- Block-diagonal noise representation lives in `gaussx` (`BlockDiagonalLinearOperator`). filterax does not reimplement.
+- Partial obs masking (e.g., missing pixels in one overpass) handled by per-instrument operators with NaN-aware reduction; filterax provides a `MaskedObsOperator` wrapper as a primitive in Wave 2.
+- Documented in `features/multi_instrument.md`; lands in Wave 2 alongside the foundation filters.
+
+---
+
+## D13: Coordinate-aware carriers via adapter, not core type
+
+**Status:** Accepted
+
+**Context:** Downstream consumers (geostack, plumax) want ensemble particles that carry coordinate metadata (CRS, affine transform, dim names) — `coordax.Array` or `GeoTensor`. The original design's `FilterState.particles: Float[Array, "N_e N_x"]` is a bare JAX array.
+
+**Options:**
+- (A) Adapter pattern — core stays JAX-array only; a `CarrierAdapter` flattens/unflattens coordax↔array around analysis calls
+- (B) PyTree leaves — relax type to allow particles to be any JAX PyTree; primitives gain an internal flatten step
+- (C) Defer
+
+**Decision:** Option A. `FilterState.particles` is `Float[Array, "N_e N_x"]` in the core type. A `CarrierAdapter` (interface, plus reference implementations for `coordax.Array` and `GeoTensor`) lives in `filterax.integrations` and provides:
+
+```python
+class CarrierAdapter(eqx.Module):
+    def flatten(self, carrier) -> tuple[Float[Array, "N_e N_x"], CarrierMeta]: ...
+    def unflatten(self, particles: Float[Array, "N_e N_x"], meta: CarrierMeta) -> Carrier: ...
+```
+
+Filters never see metadata. Adapters are user-facing convenience; the math layer stays minimal.
+
+**Consequences:**
+- Core stays lean, JAX-pure, and free of optional carrier dependencies.
+- Coordinate awareness costs one flatten/unflatten per analysis call — cheap relative to the analysis itself.
+- Downstream libraries (geostack, plumax) ship their own `CarrierAdapter` implementations; filterax ships the interface plus one reference adapter for plain dicts of named arrays.
+- Documented in `integrations/geostack.md`.
+
+---
+
+## D14: Geospatial localization owned by filterax
+
+**Status:** Accepted
+
+**Context:** The plumax Tier IV use case needs Gaspari–Cohn tapering over **geographic distance** (great-circle or projected), not grid indices. This requires:
+
+1. A way to express coordinates of state grid points and observations in a shared frame (`LocalFrame`: CRS + projection origin, built with pyproj — non-JAX, static).
+2. A distance kernel inside `jax.jit` that consumes precomputed pairwise distances and applies a taper.
+
+Geostack already disclaims responsibility for filtering math (master plan §9). pyproj produces static metadata, not JAX-traceable computation.
+
+**Options:**
+- (A) Filterax owns `GeoLocalizer`; consumes pyproj-built `LocalFrame` as static metadata
+- (B) Geostack owns `GeoLocalizer`; filterax stays generic
+- (C) Generic localizer only; users build geographic distance matrices themselves
+
+**Decision:** Option A. filterax adds `GeoLocalizer(coords, frame, radius, taper="gaspari_cohn")` to the localizer catalogue in Wave 4. `coords` are static `(N_x, 2)` lon/lat arrays; `frame` is a `LocalFrame` built once with pyproj (held as static metadata on the localizer, not inside `jax.jit`). Pairwise distances are precomputed at construction; the JIT path is just `taper(distances / radius)`.
+
+**Consequences:**
+- Adds a soft (optional) dependency on `pyproj` for `LocalFrame` construction. The localizer itself is JAX-pure once built; pyproj is not on the analysis path.
+- Distance-based covariance tapering remains filterax's core competency.
+- Documented in `features/localization_inflation.md`; lands in Wave 4.
+- Compatible with patcher-based LETKF (D16): the patcher provides per-patch coordinate slices, `GeoLocalizer` provides the per-patch taper.
+
+---
+
+## D15: Filter state is serializable
+
+**Status:** Accepted
+
+**Context:** Operational consumers (plumax alert service, long forecast cycles) need to checkpoint and restore filter state across process boundaries. The cold-start budget for the alert service is ≤5 s, so warm-started ensembles must round-trip from disk.
+
+**Decision:** `FilterState`, `ProcessState`, `UKIState`, `AnalysisResult`, `FilterConfig`, and `ProcessConfig` are fully `eqx.tree_serialise_leaves`-compatible. Wave 4 adds two thin helpers:
+
+```python
+filterax.save_state(path: str | Path, state: FilterState) -> None
+filterax.load_state(path: str | Path, like: FilterState) -> FilterState
+```
+
+These wrap `eqx.tree_serialise_leaves` / `eqx.tree_deserialise_leaves` with a versioned magic-byte header so future schema changes can be detected.
+
+**Consequences:**
+- All static-field choices on state types must be JSON-serializable scalars (int, str, bool, None). Custom classes in static fields are rejected.
+- `AbstractLinearOperator` fields inside `ProcessState` are serialized by their PyTree structure; structure must be reconstructible by gaussx.
+- Documented in `features/state_persistence.md`; lands in Wave 4.
+
+---
+
+## D16: Patcher-based localized DA lives in filterax
+
+**Status:** Accepted
+
+**Context:** Large spatial domains (continental, basin-scale) cannot fit a full ensemble × full state in device memory. The original ekalmX design includes ~1,379 lines of patch decomposition code as filterax-owned primitives. Geostack has a separate `geotoolz.patch` (incubating) for general-purpose spatial windowing.
+
+**Options:**
+- (A) filterax owns patcher implementation (sampler + stitcher) plus patcher-aware filters
+- (B) filterax consumes `geotoolz.patch` as a dependency; ships only patcher-aware filters
+- (C) Hybrid — filterax ships a minimal in-house patcher; promotes to `geotoolz.patch` consumption once that API stabilizes
+
+**Decision:** Option C. Wave 2 lands `create_patches`, `assign_obs_to_patches`, `blend_patches` as L0 primitives inside filterax (as originally planned). Wave 4 adds `LocalEnKF` / patcher-LETKF as L2 models. Once `geotoolz.patch` stabilizes (post-v0.1), filterax migrates to consuming it via an `AbstractPatcher` protocol; the in-house primitives are kept as a reference implementation and as a fallback for users who don't want a geostack dependency.
+
+**Consequences:**
+- Wave 2/4 deliverables are unchanged.
+- `AbstractPatcher` protocol added to the extension-point set in Wave 4 (mirrors `AbstractLocalizer` / `AbstractInflator`).
+- Documented in `features/localization_inflation.md` (patcher-LETKF section) and `integrations/geostack.md`.

--- a/docs/design_docs/features/differentiable_da.md
+++ b/docs/design_docs/features/differentiable_da.md
@@ -36,6 +36,14 @@ cross-validation for hyperparameters, offline regression for model error
 correction, adjoint models for 4DVar. A differentiable filter unifies all
 four under a single gradient-based framework.
 
+**Motivating downstream target.** The plumax Tier IV v2+ roadmap replaces the
+look-up-table radiative transfer model with a neural surrogate trained
+end-to-end against TROPOMI / EMIT / GHGSat radiances. The neural RTM lives
+inside the observation operator; `jax.grad` must flow through the entire
+forecast-analysis pipeline to train it. Differentiability is the design
+constraint that lets filterax be this gradient pipe rather than a black box.
+See `integrations/plumax.md` for the API sketch.
+
 ---
 
 ## 2  Why JAX Makes This Free

--- a/docs/design_docs/features/filters.md
+++ b/docs/design_docs/features/filters.md
@@ -28,6 +28,12 @@ LETKF, parametric square-root Kalman filter.
 **Out of scope:** Iterative processes (EKI, EKS — see processes.md), smoothers
 (EnKS, RTS — see smoothers.md), particle filters.
 
+**Multi-instrument fusion:** assimilating several observation streams (e.g.
+TROPOMI + EMIT + GHGSat) is handled by composing single-instrument filters
+through `JointObsOperator` (one analysis call, block-diagonal noise) or
+`SequentialAssimilation` (loop over instruments, one analysis call per
+overpass). See `features/multi_instrument.md` and Decision D12.
+
 ---
 
 ## 2  Common Mathematical Framework

--- a/docs/design_docs/features/localization_inflation.md
+++ b/docs/design_docs/features/localization_inflation.md
@@ -55,6 +55,59 @@ grid point. Observations far from the analysis point receive inflated noise and
 contribute less to the update. This is the approach used by the LETKF — each
 grid point sees only local observations with distance-weighted noise inflation.
 
+### A.2.1  Geographic localization
+
+For real-world atmospheric and oceanic applications the distance metric is
+**geographic distance** (great-circle or projected), not grid index. filterax
+ships a `GeoLocalizer` for this case (Decision D14):
+
+```python
+class GeoLocalizer(AbstractLocalizer):
+    """Gaspari-Cohn (or other taper) over geographic distance."""
+
+    coords: Float[Array, "N_x 2"]            # lon/lat of state grid points (static)
+    frame: "LocalFrame" = eqx.field(static=True)  # CRS + projection origin, built with pyproj
+    radius_km: float = eqx.field(static=True)
+    taper: str = eqx.field(static=True, default="gaspari_cohn")
+```
+
+`LocalFrame` is built **once** with `pyproj` (outside `jax.jit`) and held as
+static metadata. Pairwise distances are precomputed at construction. The JIT
+path is just `taper(distances / radius_km)`. `pyproj` is therefore a soft
+optional dependency — the localizer itself remains JAX-pure.
+
+`GeoLocalizer` pairs with patcher-based LETKF (see A.2.2) for large-domain
+assimilation: the patcher slices `coords` per patch; `GeoLocalizer` applies the
+taper inside each patch.
+
+### A.2.2  Patcher-localized LETKF
+
+Continental- or basin-scale domains do not fit a full ensemble × full state in
+device memory. filterax addresses this with patch decomposition (Decision D16):
+
+- Wave 2 L0 primitives: `create_patches`, `assign_obs_to_patches`,
+  `blend_patches`.
+- Wave 4 L2 model: `LocalEnKF` / patcher-LETKF — runs an independent LETKF
+  analysis per patch, blends overlapping regions.
+- Wave 4 extension point: `AbstractPatcher` protocol so future geostack
+  patchers (`geotoolz.patch`) can be plugged in without changing
+  filterax-side code.
+
+```python
+class AbstractPatcher(eqx.Module):
+    """Decompose a spatial domain into overlapping patches and stitch back."""
+
+    @abc.abstractmethod
+    def patches(self, state) -> Iterable["Patch"]: ...
+
+    @abc.abstractmethod
+    def stitch(self, patches: Iterable["Patch"], shape) -> Array: ...
+```
+
+filterax ships an in-house implementation in Wave 2; it migrates to
+consuming `geotoolz.patch` (still incubating in geostack) once that surface
+stabilizes.
+
 ### A.3  Gap Catalog
 
 ---

--- a/docs/design_docs/features/multi_instrument.md
+++ b/docs/design_docs/features/multi_instrument.md
@@ -1,0 +1,168 @@
+---
+status: draft
+version: 0.1.0
+---
+
+# filterax — Multi-instrument observation fusion
+
+**Subject:** API design for assimilating observations from multiple instruments with heterogeneous noise, resolution, and overpass times.
+
+**Decision anchor:** [D12](../decisions.md#d12-multi-instrument-fusion--both-joint-and-sequential-surfaces)
+
+**Lands in:** Wave 2 (`issues/wave-2-*.md`, task `FLX-24A`)
+
+---
+
+## 1  Scope
+
+Real-world data assimilation typically fuses observations from multiple sources — different satellites, different instruments on the same satellite, in-situ sensors mixed with remote sensing. These streams differ in:
+
+- **Resolution** (TROPOMI 7×7 km vs GHGSat 25 m)
+- **Noise characteristics** (retrieval covariance + representation error + temporal misalignment, all instrument-specific)
+- **Timing** (24 h revisit vs tasked-on-demand)
+- **State pieces observed** (column XCH₄ vs surface flux vs radiance)
+
+filterax does not bake multi-instrument fusion into its protocols. Instead, it provides two composition surfaces — **joint** (one analysis call) and **sequential** (one analysis call per overpass) — and lets the user choose based on the physics.
+
+**In scope:** `JointObsOperator`, `MaskedObsOperator`, `SequentialAssimilation`.
+
+**Out of scope:** instrument-specific obs operators (user / domain library code), forward modelling, averaging-kernel application (user / domain library code), 4D-Var-style joint cost over time windows (vardax).
+
+---
+
+## 2  Two surfaces, two regimes
+
+### 2.1  Joint analysis — `JointObsOperator`
+
+When multiple instruments observe the same analysis window and noise can be modelled as block-diagonal across instruments, a single joint analysis is statistically correct and computationally efficient (one Kalman gain, one update).
+
+```python
+class JointObsOperator(AbstractObsOperator):
+    """Concatenate multiple single-instrument observation operators."""
+
+    ops: tuple[AbstractObsOperator, ...]
+    noise_covs: tuple[AbstractLinearOperator, ...]
+
+    def __call__(self, state: Float[Array, "N_x"]) -> Float[Array, "N_y"]:
+        """Stack per-instrument predictions into one observation vector."""
+        return jnp.concatenate([op(state) for op in self.ops])
+
+    def noise(self) -> AbstractLinearOperator:
+        """Return block-diagonal noise covariance (via gaussx)."""
+        return gaussx.BlockDiagonalLinearOperator(self.noise_covs)
+
+    def stack_observations(self, *ys: Float[Array, "..."]) -> Float[Array, "N_y"]:
+        """Helper: stack per-instrument observation vectors in the same order as ops."""
+        return jnp.concatenate(ys)
+```
+
+**Use when:**
+
+- Overpasses are simultaneous (or within the analysis-step time tolerance).
+- Per-instrument noise is independent (no cross-instrument correlation), so block-diagonal R is correct.
+- The state pieces observed overlap, so a joint update captures cross-instrument constraint (e.g., TROPOMI XCH₄ + EMIT XCH₄ both constrain the same column).
+
+**Cost:** one Kalman gain solve on a `(N_y, N_y)` system where `N_y = Σ N_y_i`. The block-diagonal structure of R is exploited by gaussx.
+
+### 2.2  Sequential analysis — `SequentialAssimilation`
+
+When overpasses are temporally separated (an hour apart, a day apart) the joint approach is wrong: there should be a dynamics step between observations. Sequential analysis treats each overpass as its own filter step.
+
+```python
+class SequentialAssimilation(eqx.Module):
+    """Layer 2 helper: loop a filter's analysis over a list of overpasses."""
+
+    filter_: AbstractSequentialFilter
+
+    def __call__(
+        self,
+        state: FilterState,
+        overpasses: list[tuple[Array, AbstractObsOperator, AbstractLinearOperator]],
+    ) -> tuple[FilterState, list[AnalysisResult]]:
+        results = []
+        for obs, op, noise in overpasses:
+            result = self.filter_.analysis(state.particles, obs, op, noise)
+            state = FilterState(particles=result.particles, step=state.step + 1)
+            results.append(result)
+        return state, results
+```
+
+**Use when:**
+
+- Overpasses are time-staggered and there is meaningful dynamics evolution between them.
+- Per-instrument observation operators do not share state pieces (independence makes sequential equivalent to joint up to the dynamics step).
+- Memory or compute pressure makes one big `(N_y, N_y)` solve unattractive.
+
+**Cost:** `K` analyses on smaller `(N_y_i, N_y_i)` systems. Often cheaper than the joint solve when `N_y_i ≪ Σ N_y_i`.
+
+### 2.3  Equivalence
+
+When (a) noise is block-diagonal, (b) per-instrument obs operators are independent linear functions of disjoint state pieces, and (c) no dynamics step happens between overpasses — joint and sequential produce **identical posteriors**. Wave 2 ships an equivalence test on this case.
+
+When the obs operators share state pieces or noise has cross-instrument correlation, joint is correct and sequential is approximate.
+
+---
+
+## 3  Partial observations — `MaskedObsOperator`
+
+Real observations have missing pixels (cloud, snow, AOD rejection, retrieval QA failures). Filtering out masked pixels at construction time loses the fixed JIT shape; doing it inside the analysis path breaks `jax.jit`.
+
+filterax's resolution is a `MaskedObsOperator` wrapper that:
+
+1. Computes the full instrument prediction `op(state)` (fixed shape).
+2. Multiplies the observation residual by a static valid-pixel mask.
+3. Uses gaussx's noise operator to inflate the noise on masked pixels to infinity (or a large finite value).
+
+```python
+class MaskedObsOperator(AbstractObsOperator):
+    """Wrap an obs operator with a static valid-pixel mask."""
+
+    op: AbstractObsOperator
+    mask: Bool[Array, "N_y"] = eqx.field(static=False)   # not static — varies per overpass
+
+    def __call__(self, state):
+        return self.op(state)
+
+    def masked_noise(self, base_noise: AbstractLinearOperator) -> AbstractLinearOperator:
+        """Inflate noise on masked pixels."""
+        # Add a large multiple of (I - diag(mask)) to base_noise
+        ...
+```
+
+The mask is **not static** for `jax.jit` — it varies overpass to overpass — but the shape of the observation vector is. This pattern works under `jit` as long as `mask.shape == op(state).shape`.
+
+---
+
+## 4  Picking between joint and sequential
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Two coincident overpasses, independent noise | Joint |
+| Two coincident overpasses, correlated noise across instruments | Joint with full (non-block-diag) noise; gaussx supports this |
+| Three overpasses spaced 1 h apart, dynamics non-trivial | Sequential with dynamics between |
+| Three overpasses spaced 1 h apart, dynamics negligible | Either; joint is one solve, sequential is three smaller solves |
+| Joint, but one instrument is unmasked (partial pixels) | Joint with `MaskedObsOperator` per instrument |
+| Very large `N_y` (many pixels), small ensemble | Sequential — avoids one big `(N_y, N_y)` solve |
+
+The library does not auto-choose. The user decides; both surfaces are equally first-class.
+
+---
+
+## 5  Testing strategy
+
+Wave 2 ships:
+
+- **Joint shape test.** `JointObsOperator(ops, noises)(state)` shape matches `concat([op(state) for op in ops])`.
+- **Block-diagonal noise test.** `JointObsOperator.noise()` matches the dense block-diagonal reference.
+- **Equivalence test.** On a two-instrument linear Gaussian problem with block-diagonal noise and independent obs operators, joint and sequential produce posteriors that agree to numerical precision.
+- **Masking test.** A masked observation produces identical posterior to running the unmasked analysis on the surviving pixels alone.
+
+Wave 5 adds the multi-day, multi-instrument plumax smoke test (`FLX-55B`).
+
+---
+
+## 6  What we do not ship
+
+- **Cross-instrument noise correlation.** Block-diagonal noise covers the common case. For genuine cross-instrument correlation, users construct the full noise operator via gaussx directly and pass it to `filter_.analysis` — `JointObsOperator.noise()` is a convenience, not a constraint.
+- **Temporal-alignment error decomposition.** That belongs to the per-instrument noise model in user / plumax code.
+- **Auto-selection between joint and sequential.** Domain-specific; not filterax's call to make.

--- a/docs/design_docs/features/smoothers.md
+++ b/docs/design_docs/features/smoothers.md
@@ -28,6 +28,13 @@ iterative).
 **Out of scope:** Forward-only filters, EKP processes (iterative parameter
 estimation), variational smoothers (4D-Var).
 
+**Priority note (motivating use case).** The plumax Tier IV attribution use
+case (see `vision.md` "Motivating Downstream Use Case") drives post-hoc
+reconstruction of multi-day events spanning 3–5 satellite overpasses. The
+fixed-lag smoother and ensemble RTS variants are first-class deliverables in
+Wave 5, not optional extensions. See `integrations/plumax.md` for the API
+sketch.
+
 **Key insight:** All ensemble smoothers share the same backward-pass structure
 as the classical Rauch-Tung-Striebel smoother — only the gain computation and
 storage strategy differ. The smoother gain is always a cross-covariance

--- a/docs/design_docs/features/state_persistence.md
+++ b/docs/design_docs/features/state_persistence.md
@@ -1,0 +1,150 @@
+---
+status: draft
+version: 0.1.0
+---
+
+# filterax — State persistence
+
+**Subject:** Serialization contract for `FilterState`, `ProcessState`, `UKIState`, and related types. Warm-start patterns for operational deployments.
+
+**Decision anchor:** [D15](../decisions.md#d15-filter-state-is-serializable)
+
+**Lands in:** Wave 4 (`issues/wave-4-*.md`, task `FLX-46A`)
+
+---
+
+## 1  Why
+
+Operational consumers — the plumax alert service, long forecast cycles, retraining loops — need to checkpoint and restore filter state across process boundaries. Concretely:
+
+- **Plumax alert service.** Cold-start budget is ≤5 s. Re-initializing the ensemble from scratch would blow that budget; warm-starting from disk does not.
+- **Long forecast cycles.** A multi-week reanalysis is run as a chain of jobs, each picking up where the previous left off.
+- **Retraining loops.** A differentiable filter is checkpointed mid-training to recover from crashes.
+
+filterax addresses these uniformly: every state type is fully `eqx.tree_serialise_leaves`-compatible.
+
+## 2  The contract
+
+Every filterax state type satisfies the following:
+
+1. **Pure PyTree.** All non-static fields are JAX arrays or other filterax state types. No Python objects with side effects.
+2. **JSON-serializable statics.** All static fields are `int`, `str`, `bool`, `float`, `None`, or tuples thereof. No `numpy.ndarray`, no custom classes, no closures in statics. This is enforced at construction time.
+3. **Round-trippable.** `load_state(save_state(s)) == s` for every state `s`, modulo float-bit-identity.
+
+The types covered:
+
+| Type | Status |
+|------|--------|
+| `FilterState` | Required |
+| `ProcessState` | Required |
+| `UKIState` | Required |
+| `AnalysisResult` | Required |
+| `FilterConfig` | Required |
+| `ProcessConfig` | Required |
+| `AbstractDynamics` instances | Best-effort (user-defined; check their static-field types) |
+| `AbstractObsOperator` instances | Best-effort |
+
+The "best-effort" classes are user-supplied; filterax has no way to enforce the contract for them. The save/load helpers detect violations and raise a clear error.
+
+## 3  The helpers
+
+Wave 4 adds two thin wrappers around `eqx.tree_serialise_leaves`:
+
+```python
+def save_state(path: str | Path, state) -> None:
+    """Serialize a filter / process state (and friends) to disk.
+
+    Writes a 4-byte magic header (b"FAX1") followed by the eqx-serialized leaves.
+    Versioning lets future schema changes raise a clear error on load.
+    """
+
+def load_state(path: str | Path, like):
+    """Deserialize a state from disk using `like` as a structure template.
+
+    `like` must be the same type as the saved state, with leaves of matching shape
+    and dtype but arbitrary values (the standard eqx idiom).
+    """
+```
+
+Both raise `filterax.SerializationError` on:
+
+- Missing or wrong magic header (file is not a filterax state, or a future version).
+- PyTree structure mismatch between file and `like`.
+- Static-field type validation failure at construction time.
+
+## 4  Recipe — operational alert warm-start
+
+```python
+import filterax
+from pathlib import Path
+
+STATE_PATH = Path("/var/run/plumax/last_state.fax")
+
+# Template for load — empty arrays of the right shape/dtype
+template = filterax.FilterState(
+    particles=jnp.zeros((N_ENSEMBLE, N_STATE)),
+    step=0,
+)
+
+# Warm start
+state = filterax.load_state(STATE_PATH, like=template) if STATE_PATH.exists() else template
+
+# ... assimilate latest overpass into `state` ...
+
+# Persist for next run
+filterax.save_state(STATE_PATH, state)
+```
+
+The JIT-compiled analysis graph is preserved by the Python process if it stays alive; warm-start covers the case where the process is recycled (typical for serverless / FaaS deployments).
+
+## 5  Recipe — checkpointed training loop
+
+```python
+import filterax
+import equinox as eqx
+
+@eqx.filter_jit
+def step(state, batch):
+    ...
+    return new_state, loss
+
+state = init_state
+for epoch in range(N_EPOCHS):
+    for batch in dataloader:
+        state, loss = step(state, batch)
+
+    # Checkpoint every epoch
+    filterax.save_state(f"checkpoints/epoch_{epoch:03d}.fax", state)
+```
+
+Recovery picks the most recent checkpoint, deserializes, and resumes.
+
+## 6  Versioning
+
+The 4-byte magic header (`b"FAX1"`) is the only schema version filterax commits to. Schema-breaking changes (renamed fields, restructured PyTrees) bump the magic byte. Old checkpoints raise `SerializationError` on load with a clear message describing the version mismatch and pointing at a migration script (when one exists).
+
+We do **not** commit to forward compatibility — a newer filterax must be able to read older checkpoints only when there is no PyTree change.
+
+## 7  Things to be careful about
+
+### 7.1  `AbstractLinearOperator` in `ProcessState`
+
+`ProcessState.noise_cov` is a gaussx / lineax operator. Serialization works as long as the operator is itself a PyTree with JSON-serializable statics (the gaussx ones are). User-defined operators must follow the same discipline.
+
+### 7.2  PRNG keys
+
+Filter state does **not** include a PRNG key. Stochastic filters (`StochasticEnKF`) take the key as an argument to `analysis`. Users who want deterministic restart must persist their key separately.
+
+### 7.3  JIT cache
+
+`save_state` / `load_state` move **state**, not compiled code. After a fresh process, the first analysis will re-JIT. If startup latency matters, persist the JIT cache via `jax.experimental.compilation_cache`.
+
+### 7.4  Cross-platform compatibility
+
+filterax checkpoints are JAX-array bytestreams. They are **not** portable across float dtypes (a `float64` checkpoint won't load into a `float32` template). They **are** portable across CPU / GPU / TPU.
+
+## 8  Out of scope
+
+- **Streaming to remote stores** (S3, GCS) — use `fsspec` in user code; filterax takes a local path.
+- **Incremental / append-mode checkpoints** — every save is a full state dump.
+- **Schema migration tools** — when D15 needs to change, we ship a one-off migration script; not a general framework.

--- a/docs/design_docs/features/state_persistence.md
+++ b/docs/design_docs/features/state_persistence.md
@@ -75,15 +75,18 @@ Both raise `filterax.SerializationError` on:
 ## 4  Recipe — operational alert warm-start
 
 ```python
-import filterax
 from pathlib import Path
+
+import filterax
+import jax.numpy as jnp
 
 STATE_PATH = Path("/var/run/plumax/last_state.fax")
 
-# Template for load — empty arrays of the right shape/dtype
+# Template for load — empty arrays of the right shape/dtype.
+# FilterState.step is a scalar JAX integer array (Int[Array, ""]), not a Python int.
 template = filterax.FilterState(
     particles=jnp.zeros((N_ENSEMBLE, N_STATE)),
-    step=0,
+    step=jnp.array(0),
 )
 
 # Warm start

--- a/docs/design_docs/integrations/README.md
+++ b/docs/design_docs/integrations/README.md
@@ -1,0 +1,29 @@
+---
+status: draft
+version: 0.1.0
+---
+
+# Integrations
+
+Recipes for plugging filterax into the broader ecosystem. Each doc here is
+**recipe-shaped** — it shows how to use filterax with another library, not how
+to extend filterax internally.
+
+| Doc | Covers | Decision anchor |
+|-----|--------|-----------------|
+| [pipekit.md](pipekit.md) | Structural Protocol satisfaction with `pipekit-cycle`; using filterax filters inside pipekit `Sequential` / `Graph` / `Cycle` pipelines. | D11 |
+| [plumax.md](plumax.md) | Multi-instrument methane attribution (Tier IV): TROPOMI + EMIT + GHGSat fusion with `JointObsOperator`, `SequentialAssimilation`, fixed-lag smoother. | D8, D12 |
+| [geostack.md](geostack.md) | `CarrierAdapter` for coordinate-aware particles (`coordax.Array`, `GeoTensor`); `LocalFrame` construction; `GeoLocalizer` use. | D13, D14 |
+
+## What lives here vs. elsewhere
+
+- **`integrations/`** (this directory): how filterax composes with named external libraries (pipekit, plumax, geostack). Recipe form.
+- **`examples/integration.md`**: cross-cutting composition patterns (optax, somax, gaussx) that are not tied to a single downstream library.
+- **`boundaries.md`**: the ownership table that says which library owns which concern. Read this first if you want to know whether a feature belongs in filterax.
+
+## Reading order for a downstream library author
+
+1. [boundaries.md](../boundaries.md) — confirm filterax is the right place to plug in
+2. [pipekit.md](pipekit.md) — if your pipeline is a pipekit `Sequential` / `Graph`
+3. [geostack.md](geostack.md) — if your particles are coordinate-aware
+4. [plumax.md](plumax.md) — if you are fusing multiple observation streams

--- a/docs/design_docs/integrations/geostack.md
+++ b/docs/design_docs/integrations/geostack.md
@@ -1,0 +1,179 @@
+---
+status: draft
+version: 0.1.0
+---
+
+# filterax × geostack — coordinate-aware ensembles
+
+**Subject:** How to run filterax on ensembles whose particles carry CRS, named dimensions, and time coordinates (`coordax.Array` / `GeoTensor`).
+
+**Decision anchors:** [D13 (carrier adapter)](../decisions.md#d13-coordinate-aware-carriers-via-adapter-not-core-type), [D14 (GeoLocalizer)](../decisions.md#d14-geospatial-localization-owned-by-filterax), [D16 (patcher)](../decisions.md#d16-patcher-based-localized-da-lives-in-filterax)
+
+---
+
+## 1  What geostack provides
+
+The geostack ecosystem (`georeader`, `GeoCatalog`, `geotoolz`, `xrtoolz`) ships:
+
+- `georeader.GeoTensor` — typed raster carrier with CRS + affine transform.
+- `coordax.Array` — JAX-native coordinate-aware array (still maturing).
+- `geotoolz.patch` (incubating) — spatial sampler + stitcher.
+
+filterax does **not** ship any of these. The integration story is two seams:
+
+1. **Carrier adapter** — turn a coordinate-aware ensemble into `Float[Array, "N_e N_x"]` for analysis, and back.
+2. **Geographic localization** — consume coordinates as static metadata for `GeoLocalizer` (per D14).
+
+## 2  The carrier adapter
+
+Filters operate on flat ensemble arrays. Coordinate-aware carriers are handled outside the math layer by a `CarrierAdapter`:
+
+```python
+class CarrierAdapter(eqx.Module):
+    """Round-trip a coordinate-aware carrier to/from FilterState.particles."""
+
+    @abc.abstractmethod
+    def flatten(self, carrier) -> tuple[Float[Array, "N_e N_x"], "CarrierMeta"]:
+        ...
+
+    @abc.abstractmethod
+    def unflatten(self, particles, meta) -> Any:
+        ...
+```
+
+filterax ships two reference implementations in `filterax.integrations`:
+
+| Adapter | Carrier | When to use |
+|---------|---------|-------------|
+| `DictAdapter` | `dict[str, Array]` of named state fields | Mixed-shape state (scalars + grids), no spatial coords needed |
+| `CoordaxAdapter` | `coordax.Array` | Pure spatial state, coordinates needed for localization |
+
+`coordax` is a soft (optional) dependency — `CoordaxAdapter` is imported lazily. The core filterax install does not pull in coordax.
+
+## 3  DictAdapter recipe
+
+For a plumax-style state that mixes scalar parameters and gridded fields:
+
+```python
+import filterax
+import jax.numpy as jnp
+
+adapter = filterax.integrations.DictAdapter(
+    schema={
+        "Q":      (4,),        # 4 source rates
+        "x0":     (4, 2),      # 4 source positions
+        "c_bg":   (),          # background scalar
+        "b_inst": (3,),        # 3 instrument biases
+    }
+)
+
+ensemble = {
+    "Q":      jnp.zeros((N_e, 4)),
+    "x0":     jnp.zeros((N_e, 4, 2)),
+    "c_bg":   jnp.zeros((N_e,)),
+    "b_inst": jnp.zeros((N_e, 3)),
+}
+
+particles, meta = adapter.flatten(ensemble)   # (N_e, 4 + 8 + 1 + 3) = (N_e, 16)
+
+# ... analysis on flat particles ...
+
+new_ensemble = adapter.unflatten(updated_particles, meta)
+```
+
+The schema is **static**, captured in `meta` as a tuple of `(name, shape, slice)` records. JIT picks up the slicing as static structure; the flatten/unflatten round-trip is essentially free at runtime.
+
+## 4  CoordaxAdapter recipe
+
+For a 2D spatial state with lon/lat coordinates:
+
+```python
+import coordax
+import filterax
+
+state = coordax.Array(
+    data=jnp.zeros((N_e, n_lat, n_lon)),
+    dims=("ensemble", "lat", "lon"),
+    coords={"lat": lat_array, "lon": lon_array},
+)
+
+adapter = filterax.integrations.CoordaxAdapter(ensemble_dim="ensemble")
+
+particles, meta = adapter.flatten(state)
+# particles: (N_e, n_lat * n_lon)
+# meta: CarrierMeta(dims=("lat", "lon"), shape=(n_lat, n_lon), coords={...})
+
+# ... analysis ...
+
+state_a = adapter.unflatten(updated_particles, meta)
+# state_a is a coordax.Array with the same dims and coords as input
+```
+
+The adapter preserves dim order and coordinate arrays; only the underlying data buffer is replaced.
+
+## 5  Geographic localization
+
+`GeoLocalizer` consumes coordinates as static metadata (see `features/localization_inflation.md` §A.2.1 and D14):
+
+```python
+import filterax
+import numpy as np
+
+# coords: (N_x, 2) lon/lat array of state grid points
+coords = np.column_stack([lon_array.ravel(), lat_array.ravel()])
+
+frame = filterax.LocalFrame.from_crs(
+    src_crs="EPSG:4326",
+    dst_crs="EPSG:32633",      # UTM zone 33N — projection appropriate for AOI
+    origin=(lon0, lat0),
+)
+
+localizer = filterax.GeoLocalizer(
+    coords=coords,
+    frame=frame,
+    radius_km=50.0,
+    taper="gaspari_cohn",
+)
+
+filter_ = filterax.LETKF(localizer=localizer, ...)
+```
+
+`LocalFrame.from_crs` is the only step that calls `pyproj`; it runs once at construction time. The `GeoLocalizer.__call__` path is pure JAX.
+
+## 6  Patcher integration
+
+filterax ships an in-house `RegularGridPatcher` in Wave 2 and an `AbstractPatcher` extension point in Wave 4 (D16). When `geotoolz.patch` stabilizes, geostack users can plug it in directly:
+
+```python
+from geotoolz.patch import GridSampler, Stitcher       # post-stabilization
+
+class GeoPatcher(filterax.AbstractPatcher):
+    sampler: GridSampler = eqx.field(static=True)
+    stitcher: Stitcher = eqx.field(static=True)
+
+    def patches(self, state):
+        return self.sampler(state)
+
+    def stitch(self, patches, shape):
+        return self.stitcher(patches, shape)
+
+local_filter = filterax.LocalEnKF(
+    base_filter=filterax.LETKF(...),
+    patcher=GeoPatcher(sampler=..., stitcher=...),
+)
+```
+
+Until then, `LocalEnKF` consumes the in-house patcher; the user-facing API is identical.
+
+## 7  Things filterax deliberately does *not* ship
+
+- **No coordax / GeoTensor / pyproj** in the required dependency set. All three are soft-optional.
+- **No xarray adapter.** xarray orchestration belongs to `xr_assimilate` (see `boundaries.md`).
+- **No CRS reprojection.** Pre-project coordinates before constructing the localizer; reprojection inside the analysis path is not a filterax concern.
+- **No catalog / I/O.** `GeoCatalog`, `georeader`, and friends are upstream of filterax.
+
+## 8  Migration outlook
+
+The carrier adapter pattern is intentionally minimal so filterax can absorb whatever coordinate library wins out (`coordax`, `xarray`, `GeoTensor`). The interface is short enough that an adapter for a new carrier is ~30 lines of user code.
+
+If a future ecosystem decision settles on one carrier library, filterax can promote that adapter to the core install — without changing the math layer.

--- a/docs/design_docs/integrations/geostack.md
+++ b/docs/design_docs/integrations/geostack.md
@@ -41,14 +41,15 @@ class CarrierAdapter(eqx.Module):
         ...
 ```
 
-filterax ships two reference implementations in `filterax.integrations`:
+filterax ships **one** reference implementation:
 
-| Adapter | Carrier | When to use |
-|---------|---------|-------------|
-| `DictAdapter` | `dict[str, Array]` of named state fields | Mixed-shape state (scalars + grids), no spatial coords needed |
-| `CoordaxAdapter` | `coordax.Array` | Pure spatial state, coordinates needed for localization |
+| Adapter | Carrier | When to use | Owner |
+|---------|---------|-------------|-------|
+| `DictAdapter` | `dict[str, Array]` of named state fields | Mixed-shape state (scalars + grids), no spatial coords needed | **filterax** |
+| `CoordaxAdapter` | `coordax.Array` | Pure spatial state, coordinates needed for localization | downstream (geostack / plumax) |
+| `GeoTensorAdapter` | `georeader.GeoTensor` | Raster particles with CRS + affine transform | downstream (geostack) |
 
-`coordax` is a soft (optional) dependency — `CoordaxAdapter` is imported lazily. The core filterax install does not pull in coordax.
+filterax does **not** depend on `coordax`, `georeader`, or `pyproj` for the carrier path. Coordinate-aware adapters are recipe-level documentation here; the implementations live in the libraries that own those carrier types. §4 below shows the expected shape so downstream authors stay consistent with filterax's interface.
 
 ## 3  DictAdapter recipe
 
@@ -83,13 +84,27 @@ new_ensemble = adapter.unflatten(updated_particles, meta)
 
 The schema is **static**, captured in `meta` as a tuple of `(name, shape, slice)` records. JIT picks up the slicing as static structure; the flatten/unflatten round-trip is essentially free at runtime.
 
-## 4  CoordaxAdapter recipe
+## 4  CoordaxAdapter recipe (downstream-owned)
 
-For a 2D spatial state with lon/lat coordinates:
+Shape that a `coordax.Array` adapter should follow when authored in geostack / plumax / user code. **filterax does not ship this class** — it is documented here so downstream authors stay consistent with the `CarrierAdapter` interface in §2:
 
 ```python
 import coordax
+import jax.numpy as jnp
 import filterax
+
+class CoordaxAdapter(filterax.CarrierAdapter):
+    """Round-trip a coordax.Array ensemble carrier (downstream / user-owned)."""
+
+    ensemble_dim: str = "ensemble"
+
+    def flatten(self, carrier):
+        # ... extract data, dims, coords; reshape to (N_e, N_x) ...
+        ...
+
+    def unflatten(self, particles, meta):
+        # ... rebuild coordax.Array from data + saved dims/coords ...
+        ...
 
 state = coordax.Array(
     data=jnp.zeros((N_e, n_lat, n_lon)),
@@ -97,8 +112,7 @@ state = coordax.Array(
     coords={"lat": lat_array, "lon": lon_array},
 )
 
-adapter = filterax.integrations.CoordaxAdapter(ensemble_dim="ensemble")
-
+adapter = CoordaxAdapter(ensemble_dim="ensemble")
 particles, meta = adapter.flatten(state)
 # particles: (N_e, n_lat * n_lon)
 # meta: CarrierMeta(dims=("lat", "lon"), shape=(n_lat, n_lon), coords={...})
@@ -109,7 +123,7 @@ state_a = adapter.unflatten(updated_particles, meta)
 # state_a is a coordax.Array with the same dims and coords as input
 ```
 
-The adapter preserves dim order and coordinate arrays; only the underlying data buffer is replaced.
+The adapter preserves dim order and coordinate arrays; only the underlying data buffer is replaced. Authoring this in geostack or plumax keeps `coordax` (and any other carrier-side dependency) out of filterax's install.
 
 ## 5  Geographic localization
 

--- a/docs/design_docs/integrations/pipekit.md
+++ b/docs/design_docs/integrations/pipekit.md
@@ -1,0 +1,162 @@
+---
+status: draft
+version: 0.1.0
+---
+
+# filterax × pipekit-cycle
+
+**Subject:** How filterax slots into `pipekit-cycle` pipelines without importing pipekit.
+
+**Decision anchor:** [D11 — Structural Protocol satisfaction](../decisions.md#d11-pipekit-cycle-protocol-compatibility--structural-only)
+
+---
+
+## 1  The problem
+
+`pipekit-cycle` defines three `@runtime_checkable` Protocols that describe a generic data-assimilation cycle:
+
+```python
+# from pipekit_cycle.protocols
+@runtime_checkable
+class ForwardModel(Protocol):
+    def step(self, state, dt) -> state: ...
+    @property
+    def dt(self) -> float: ...
+    @property
+    def state_signature(self) -> Any: ...
+
+@runtime_checkable
+class ObservationOperator(Protocol):
+    def __call__(self, state) -> obs: ...
+    def linearize(self, state) -> Callable: ...
+
+@runtime_checkable
+class AnalysisStep(Protocol):
+    def __call__(self, forecast, obs, *, obs_op, obs_err_cov) -> analysis: ...
+```
+
+These overlap with filterax's `AbstractDynamics`, `AbstractObsOperator`, and `AbstractSequentialFilter`. A filterax filter should drop into a pipekit `Sequential` / `Graph` / `Cycle` without:
+
+- forcing every filterax user to install pipekit, or
+- forcing filterax to track pipekit's protocol churn.
+
+## 2  The decision
+
+filterax classes **structurally satisfy** the pipekit Protocols — same method names, same call shapes — but filterax itself **never imports pipekit**. The compatibility is duck-typed; `@runtime_checkable` makes `isinstance(filter, pipekit_cycle.AnalysisStep)` work at runtime without inheritance.
+
+This mirrors pipekit's own rule (algorithm libraries do not import pipekit). It also matches how `vardax`, `pyrox_gp`, and other ecosystem libraries integrate.
+
+## 3  Compatibility table
+
+| filterax surface | pipekit Protocol | Adapter required? |
+|------------------|------------------|-------------------|
+| `AbstractDynamics.__call__(state, t0, t1)` | `ForwardModel.step(state, dt)` | One-line wrapper (see §4.1) |
+| `AbstractObsOperator.__call__(state)` | `ObservationOperator.__call__(state)` | None — identical surface |
+| `AbstractObsOperator.linearize(state)` *(optional)* | `ObservationOperator.linearize(state)` | None when present |
+| `AbstractSequentialFilter.analysis(forecast, obs, obs_op, obs_noise)` | `AnalysisStep.__call__(forecast, obs, *, obs_op, obs_err_cov)` | One-line wrapper (see §4.2) |
+
+The Dynamics and AnalysisStep surfaces differ in argument names and time-stepping convention; both are bridged by trivial wrappers users write in their own code.
+
+## 4  Recipes
+
+### 4.1  Use a filterax filter as a pipekit `AnalysisStep`
+
+```python
+# user code — neither filterax nor pipekit-cycle imports the other
+import filterax
+import pipekit_cycle as pkc
+
+filter_ = filterax.ETKF()  # or LETKF, EnSRF, ...
+
+class FilterAsAnalysisStep:
+    """Bridge filterax.AbstractSequentialFilter.analysis -> pkc.AnalysisStep."""
+
+    def __init__(self, filter_):
+        self._filter = filter_
+
+    def __call__(self, forecast, obs, *, obs_op, obs_err_cov):
+        return self._filter.analysis(forecast, obs, obs_op, obs_err_cov)
+
+step = FilterAsAnalysisStep(filter_)
+assert isinstance(step, pkc.AnalysisStep)   # passes — runtime_checkable
+```
+
+### 4.2  Use a filterax dynamics inside a pipekit `Cycle`
+
+filterax `AbstractDynamics.__call__(state, t0, t1)` carries explicit start and end times; pipekit's `step(state, dt)` carries a step size. The bridge is one line:
+
+```python
+class DynamicsAsForwardModel:
+    def __init__(self, dyn, dt):
+        self._dyn = dyn
+        self.dt = dt
+
+    def step(self, state, dt=None):
+        dt = self.dt if dt is None else dt
+        return self._dyn(state, 0.0, dt)
+```
+
+`state_signature` is optional in pipekit; provide it if you want pipekit's shape inference. filterax does not require it.
+
+### 4.3  Wrap a filter as a pipekit `StatefulOperator`
+
+pipekit threads `(carrier, state) -> (carrier, state)` through `Sequential` graphs. A filterax filter does not own its history; the user does. The wrapper is again user-side:
+
+```python
+import equinox as eqx
+import pipekit as pk
+
+class FilterCycle(pk.StatefulOperator):
+    """A filterax filter wrapped as a stateful pipekit operator."""
+
+    _is_stateful = True
+
+    filter_: filterax.AbstractSequentialFilter
+    obs_op: filterax.AbstractObsOperator
+    obs_noise: Any                # gaussx / lineax operator
+
+    def _apply(self, carrier, state):
+        # carrier: (forecast_ensemble, obs) tuple
+        # state: filterax.FilterState
+        forecast, obs = carrier
+        result = self.filter_.analysis(forecast, obs, self.obs_op, self.obs_noise)
+        new_state = filterax.FilterState(
+            particles=result.particles,
+            step=state.step + 1,
+        )
+        return result, new_state
+```
+
+## 5  Naming and signature alignment
+
+filterax keeps method names and argument orders in step with pipekit's Protocols whenever there is no domain reason to diverge. Where they do diverge:
+
+- **Time arguments.** filterax dynamics take `(state, t0, t1)` (start, end). pipekit takes `(state, dt)` (step size). Bridge in user code; do not force one convention on the other.
+- **Noise covariance.** filterax accepts an `AbstractLinearOperator` (gaussx-shaped). pipekit accepts any array-shaped covariance. The wrapper passes through; gaussx operators behave like arrays for elementwise use.
+
+## 6  What we do *not* ship
+
+- `filterax.integrations.pipekit` is **not** a module. There is no Python code in filterax that mentions pipekit.
+- The wrappers above live in user code or in pipekit-cycle's own examples.
+
+## 7  Testing the contract
+
+filterax does not test pipekit compatibility directly. Wave 5 adds an opt-in test guarded by `pytest.importorskip("pipekit_cycle")`:
+
+```python
+def test_filter_satisfies_pipekit_analysis_step():
+    import pipekit_cycle as pkc
+    filter_ = filterax.ETKF()
+    step = FilterAsAnalysisStep(filter_)
+    assert isinstance(step, pkc.AnalysisStep)
+```
+
+This catches accidental signature drift without coupling the libraries at import time. See `issues/wave-5-*.md` task `FLX-55A`.
+
+## 8  Why not just import pipekit?
+
+- **Optionality.** filterax should run for users who don't use pipekit at all.
+- **Versioning.** pipekit's Protocols are still pre-1.0. Importing them locks filterax to a moving target.
+- **Symmetry.** `vardax`, `pyrox_gp`, and other algorithm libraries follow the same rule. The ecosystem decision is consistent.
+
+If the cost of duck typing becomes untenable (e.g., pipekit grows non-trivial helper functions every filterax user wants), revisit by adding `filterax[pipekit]` extras with a thin adapter module. That is a future change, not a current commitment.

--- a/docs/design_docs/integrations/pipekit.md
+++ b/docs/design_docs/integrations/pipekit.md
@@ -103,7 +103,9 @@ class DynamicsAsForwardModel:
 pipekit threads `(carrier, state) -> (carrier, state)` through `Sequential` graphs. A filterax filter does not own its history; the user does. The wrapper is again user-side:
 
 ```python
-import equinox as eqx
+from typing import Any
+
+import filterax
 import pipekit as pk
 
 class FilterCycle(pk.StatefulOperator):

--- a/docs/design_docs/integrations/plumax.md
+++ b/docs/design_docs/integrations/plumax.md
@@ -83,31 +83,37 @@ result = filter_.analysis(
 When overpasses are an hour apart and there is no benefit to joint treatment:
 
 ```python
+import jax.numpy as jnp
+
 overpasses = [
-    (y_trop_t0,  TROPOMIOp(...),  TROPOMINoise(...)),
-    (y_emit_t1,  EMITOp(...),     EMITNoise(...)),
-    (y_ghgsat_t2, GHGSatOp(...),   GHGSatNoise(...)),
+    (y_trop_t0,   TROPOMIOp(...), TROPOMINoise(...)),
+    (y_emit_t1,   EMITOp(...),    EMITNoise(...)),
+    (y_ghgsat_t2, GHGSatOp(...),  GHGSatNoise(...)),
 ]
 
 cycle = filterax.SequentialAssimilation(filter_)
-state = filterax.FilterState(particles=forecast_ensemble, step=0)
-for obs, op, noise in overpasses:
-    state, result = cycle(state, obs, op, noise)
+state = filterax.FilterState(particles=forecast_ensemble, step=jnp.array(0))
+final_state, results = cycle(state, overpasses)
 ```
 
-`SequentialAssimilation` is a Layer 2 helper that loops `filter_.analysis` and returns the final `FilterState` plus the trail of `AnalysisResult` for diagnostics. The user dynamics are still responsible for propagating the ensemble between overpasses.
+`SequentialAssimilation.__call__(state, overpasses)` consumes the full list of `(obs, obs_op, obs_noise)` tuples in one call (see `features/multi_instrument.md` §2.2) and returns the final `FilterState` plus the trail of `AnalysisResult` for diagnostics. The user dynamics are still responsible for propagating the ensemble between overpasses — see §5 for the inter-overpass case.
 
 ## 5  Multi-day event reconstruction (fixed-lag smoother)
 
-A plume event spans 12–24 hours and 3–5 overpasses. Operational triage uses the filter trail; the post-hoc attribution report uses a fixed-lag smoother to incorporate future observations:
+A plume event spans 12–24 hours and 3–5 overpasses with non-trivial dynamics in between. Operational triage uses the filter trail; the post-hoc attribution report uses a fixed-lag smoother to incorporate future observations. When dynamics matter between overpasses, run one analysis per step (rather than batching them through `SequentialAssimilation`):
 
 ```python
 filter_results = []
-state = filterax.FilterState(particles=init, step=0)
-for t, (obs, op, noise) in enumerate(overpasses):
+forecast_history = []
+state = filterax.FilterState(particles=init, step=jnp.array(0))
+t_prev = 0.0
+for t, (obs, op, noise) in zip(overpass_times, overpasses):
     forecast = dynamics_step(state.particles, t_prev, t)
-    state, result = cycle(filterax.FilterState(forecast, t), obs, op, noise)
+    forecast_history.append(forecast)
+    result = filter_.analysis(forecast, obs, op, noise)
+    state = filterax.FilterState(particles=result.particles, step=state.step + 1)
     filter_results.append(result)
+    t_prev = t
 
 smoother = filterax.FixedLagSmoother(lag=5)
 smoothed = smoother.smooth(filter_results, forecast_history)

--- a/docs/design_docs/integrations/plumax.md
+++ b/docs/design_docs/integrations/plumax.md
@@ -1,0 +1,171 @@
+---
+status: draft
+version: 0.1.0
+---
+
+# filterax × plumax — Tier IV multi-instrument methane attribution
+
+**Subject:** Worked API sketch for fusing TROPOMI + EMIT + GHGSat observations into a joint posterior over methane source rates, positions, wind, and instrument biases.
+
+**Decision anchors:** [D8 (smoothers in core)](../decisions.md#d8-smoothers-are-in-scope-core-library), [D12 (multi-instrument)](../decisions.md#d12-multi-instrument-fusion--both-joint-and-sequential-surfaces), [D13 (carrier adapter)](../decisions.md#d13-coordinate-aware-carriers-via-adapter-not-core-type), [D14 (GeoLocalizer)](../decisions.md#d14-geospatial-localization-owned-by-filterax), [D15 (state persistence)](../decisions.md#d15-filter-state-is-serializable)
+
+> This document is **API-shape only**. It does not import plumax; plumax does not ship yet. The point is to validate that filterax surfaces compose into the target use case without further design changes.
+
+---
+
+## 1  The Tier IV problem
+
+The plumax stack fuses three satellite observation streams into a joint posterior over a methane attribution state vector:
+
+| Symbol | Meaning | Dimensionality |
+|--------|---------|----------------|
+| `Q(t)` | Source rates over `K` candidate locations | `K × T` |
+| `x₀` | Source positions | `K × 2` |
+| `ū`, `θ_wind` | Wind speed and direction | `~10` |
+| `c_bg` | Background concentration | `~1` |
+| `b_inst` | Per-instrument bias offset (TROPOMI, EMIT, GHGSat) | `3` |
+| `A_surf`, `AOD` | Surface albedo, aerosol optical depth | `~10` |
+
+State dimensionality: ~20 (Tier I Gaussian plume) to ~10⁴ (Tier III Eulerian transport on a regional grid). Ensemble size 50–1000.
+
+Observations arrive **at different times** (TROPOMI 24 h revisit, EMIT ISS cadence, GHGSat tasked) **at different native resolutions** (TROPOMI 7×7 km, EMIT 60 m, GHGSat 25 m) with **different noise models** (retrieval covariance + representation error + temporal-alignment error per instrument).
+
+## 2  Mapping plumax components to filterax surfaces
+
+| plumax component | filterax surface | Notes |
+|------------------|------------------|-------|
+| Tier II/III transport model | `AbstractDynamics` | Stepped via `eqx.filter_vmap` over ensemble |
+| RTM + averaging kernel application | `AbstractObsOperator` (per instrument) | One per satellite |
+| Per-instrument noise (R_retr + R_repr + R_align) | `AbstractNoise` (per instrument) → gaussx `LowRankUpdate + Diagonal` | Block-diagonal for joint analysis |
+| TROPOMI ⊕ EMIT ⊕ GHGSat fusion | `JointObsOperator(ops, noises)` *or* `SequentialAssimilation(filter)` | D12 |
+| Geographic Gaspari–Cohn over plume footprint | `GeoLocalizer(coords, frame, radius_km=50)` | D14 |
+| Continental / basin domain decomposition | `LocalEnKF` (patcher-LETKF) | D16 |
+| Coordinate-aware ensembles | `CarrierAdapter` for `coordax.Array` | D13 |
+| Multi-day event reconstruction | `FixedLagSmoother(lag=5)` or `EnsembleRTS` | Wave 5 |
+| Operational alert warm-start | `save_state` / `load_state` | D15 |
+
+## 3  Joint-analysis recipe (simultaneous overpass)
+
+When two instruments observe overlapping pixels within the same analysis window (e.g., a coincident TROPOMI + EMIT overpass) a single joint analysis is correct:
+
+```python
+import filterax
+from plumax.obs import TROPOMIOp, EMITOp, GHGSatOp        # user / plumax-side
+from plumax.noise import TROPOMINoise, EMITNoise, GHGSatNoise
+
+joint_op = filterax.JointObsOperator(
+    ops=(TROPOMIOp(ak_path=...), EMITOp(...), GHGSatOp(...)),
+    noise_covs=(TROPOMINoise(...), EMITNoise(...), GHGSatNoise(...)),
+)
+
+filter_ = filterax.LETKF(
+    localizer=filterax.GeoLocalizer(
+        coords=state_lonlat,
+        frame=filterax.LocalFrame.from_crs("EPSG:4326", origin=(lon0, lat0)),
+        radius_km=50.0,
+    ),
+    inflator=filterax.RTPS(alpha=0.8),
+    config=filterax.FilterConfig(n_ensemble=200),
+)
+
+result = filter_.analysis(
+    particles=forecast_ensemble,
+    obs=joint_op.stack_observations(y_trop, y_emit, y_ghgsat),
+    obs_op=joint_op,
+    obs_noise=joint_op.noise(),       # block-diagonal
+)
+```
+
+`JointObsOperator.stack_observations` concatenates the three observation vectors; `joint_op.noise()` returns a block-diagonal `gaussx.BlockDiagonalLinearOperator` over the three per-instrument noise operators.
+
+## 4  Sequential-analysis recipe (temporally separated overpasses)
+
+When overpasses are an hour apart and there is no benefit to joint treatment:
+
+```python
+overpasses = [
+    (y_trop_t0,  TROPOMIOp(...),  TROPOMINoise(...)),
+    (y_emit_t1,  EMITOp(...),     EMITNoise(...)),
+    (y_ghgsat_t2, GHGSatOp(...),   GHGSatNoise(...)),
+]
+
+cycle = filterax.SequentialAssimilation(filter_)
+state = filterax.FilterState(particles=forecast_ensemble, step=0)
+for obs, op, noise in overpasses:
+    state, result = cycle(state, obs, op, noise)
+```
+
+`SequentialAssimilation` is a Layer 2 helper that loops `filter_.analysis` and returns the final `FilterState` plus the trail of `AnalysisResult` for diagnostics. The user dynamics are still responsible for propagating the ensemble between overpasses.
+
+## 5  Multi-day event reconstruction (fixed-lag smoother)
+
+A plume event spans 12–24 hours and 3–5 overpasses. Operational triage uses the filter trail; the post-hoc attribution report uses a fixed-lag smoother to incorporate future observations:
+
+```python
+filter_results = []
+state = filterax.FilterState(particles=init, step=0)
+for t, (obs, op, noise) in enumerate(overpasses):
+    forecast = dynamics_step(state.particles, t_prev, t)
+    state, result = cycle(filterax.FilterState(forecast, t), obs, op, noise)
+    filter_results.append(result)
+
+smoother = filterax.FixedLagSmoother(lag=5)
+smoothed = smoother.smooth(filter_results, forecast_history)
+```
+
+## 6  Operational alert warm-start
+
+Cold-start budget for the alert service is ≤5 s. The warm ensemble is loaded from disk per D15:
+
+```python
+state = filterax.load_state("/var/run/plumax/last_state.fax", like=template_state)
+forecast = dynamics_step(state.particles, state.step, state.step + 1)
+# ... assimilate latest overpass ...
+filterax.save_state("/var/run/plumax/last_state.fax", new_state)
+```
+
+The first analysis after warm-start reuses the JIT-compiled graph from the previous run; the only cost is the disk read plus the analysis itself.
+
+## 7  Differentiable RTM (Tier IV v2+)
+
+Tier IV v2 replaces the look-up-table RTM with a neural surrogate trained against L1 radiance. The training signal is the observation-space log-likelihood through the full filter:
+
+```python
+@eqx.filter_jit
+@eqx.filter_value_and_grad
+def loss(rtm_params, ensemble, observations):
+    obs_op = NeuralRTMObsOp(rtm_params)
+    state = filterax.FilterState(ensemble, 0)
+    nll = 0.0
+    for obs in observations:
+        result = filter_.analysis(state.particles, obs, obs_op, noise)
+        nll = nll - result.log_likelihood
+        state = filterax.FilterState(result.particles, state.step + 1)
+    return nll
+
+value, grad = loss(rtm_params, ensemble, observations)
+```
+
+filterax's only contribution is staying differentiable. The neural network and training loop are user-owned.
+
+## 8  Open seams
+
+These are concrete things plumax will pressure-test once both libraries mature:
+
+1. **Block-diagonal noise representation.** `JointObsOperator.noise()` relies on gaussx's `BlockDiagonalLinearOperator`. Confirm gaussx ships that surface before Wave 2 closes.
+2. **Partial obs masking.** Real overpasses have cloud-masked pixels. `MaskedObsOperator` (Wave 2) wraps a per-instrument op with a NaN-aware reduction. Plumax should validate the masking semantics on real TROPOMI L2.
+3. **`coordax.Array` adapter.** filterax ships only the interface plus a `dict[str, Array]` reference adapter. Plumax (or geostack) needs to author the `coordax.Array` adapter once coordax stabilizes.
+4. **Patcher API.** filterax ships an in-house patcher in Wave 2 (D16). Migration to `geotoolz.patch` is deferred until geostack's patcher stabilizes.
+
+None of these change the filterax design — they're all downstream / sibling-library deliverables.
+
+## 9  Acceptance for filterax
+
+filterax considers the plumax integration complete when:
+
+- Joint and sequential analyses on a synthetic two-instrument linear Gaussian problem produce identical posteriors (when noise is block-diagonal and obs are independent).
+- `GeoLocalizer` produces a Gaspari–Cohn taper that matches a reference NumPy implementation to 1e-6 on a 100-point lon/lat grid.
+- A warm-start cycle (load_state → analysis → save_state) preserves the ensemble bit-for-bit.
+- The differentiable Tier IV v2 loss above produces finite gradients on a synthetic problem.
+
+These land as smoke + correctness tests in Wave 5 (see `issues/wave-5-*.md`, task `FLX-55B`).

--- a/docs/design_docs/issues/wave-2-sequential-filtering-foundation.md
+++ b/docs/design_docs/issues/wave-2-sequential-filtering-foundation.md
@@ -41,6 +41,8 @@ After this wave, later work should be able to assume:
 - `create_patches`, `assign_obs_to_patches`, `blend_patches`
 - `StochasticEnKF`, `ETKF`, `EnSRF`, `LETKF`
 - high-level `ETKF`, `EnSRF`, and `LETKF` assimilation models
+- `JointObsOperator(ops, noise_covs)` combinator + `MaskedObsOperator` wrapper
+- `SequentialAssimilation(filter)` Layer 2 helper (D12, `features/multi_instrument.md`)
 
 ## Canonical API Snapshot
 The design docs suggest two main user-facing entry patterns in this wave.
@@ -343,6 +345,41 @@ analysis-step components.
 ## Relationships
 - Parent epic: FLX-17.
 - Blocked by FLX-22 and FLX-23.
+
+---
+
+# filters(multi-instrument): implement JointObsOperator, MaskedObsOperator, and SequentialAssimilation
+Draft ID: `FLX-24A`
+## Problem / Request
+Provide the two surfaces for multi-instrument fusion mandated by Decision D12.
+
+## Motivation
+The plumax/geostack motivating use case (see `vision.md`) assimilates TROPOMI,
+EMIT, and GHGSat observations at heterogeneous resolutions and overpass times.
+Single-instrument analysis is insufficient.
+
+## References & Existing Code
+- Design doc / spec: `design_docs/features/multi_instrument.md`,
+  `design_docs/decisions.md` (D12), `design_docs/integrations/plumax.md`
+
+## Implementation Steps
+- [ ] Implement `JointObsOperator(ops, noise_covs)` returning a stacked obs
+      vector and block-diagonal noise (via `gaussx`).
+- [ ] Implement `MaskedObsOperator(op, mask_fn)` wrapper for partial obs / NaN
+      masking.
+- [ ] Implement `SequentialAssimilation(filter)` Layer 2 helper that loops
+      `filter.analysis` over a list of `(obs, obs_op, obs_noise)` tuples.
+- [ ] Add joint-vs-sequential equivalence test on a 2-instrument linear
+      Gaussian problem (block-diagonal R, independent obs ⇒ identical
+      posterior).
+
+## Definition of Done
+- Users can fuse 2+ observation streams either jointly or sequentially without
+  rewriting their filter.
+
+## Relationships
+- Parent epic: FLX-17.
+- Blocked by FLX-22.
 
 ---
 

--- a/docs/design_docs/issues/wave-4-advanced-filtering-and-diagnostics.md
+++ b/docs/design_docs/issues/wave-4-advanced-filtering-and-diagnostics.md
@@ -226,6 +226,110 @@ covariance diagnosis.
 
 ---
 
+# localization(geo): implement GeoLocalizer with pyproj-built LocalFrame
+Draft ID: `FLX-43A`
+## Problem / Request
+Add geographic-distance localization for atmospheric / oceanic use cases per
+Decision D14.
+
+## Motivation
+The plumax/geostack motivating use case requires Gaspari–Cohn tapering over
+great-circle or projected distance — not grid index. `pyproj` builds the
+`LocalFrame` once outside `jax.jit`; the JIT path is pure JAX.
+
+## References & Existing Code
+- Design doc / spec:
+  `design_docs/features/localization_inflation.md` §A.2.1,
+  `design_docs/decisions.md` (D14),
+  `design_docs/integrations/geostack.md`
+
+## Implementation Steps
+- [ ] Define `LocalFrame` (static metadata: CRS, projection origin, optional
+      pyproj transformer).
+- [ ] Implement `GeoLocalizer(coords, frame, radius_km, taper)`.
+- [ ] Precompute pairwise distances at construction; keep JIT path pure JAX.
+- [ ] Add `pyproj` as a soft optional dependency (extras: `filterax[geo]`).
+- [ ] Test: great-circle distance taper matches Gaspari–Cohn shape; survives
+      `jax.jit` once constructed.
+
+## Definition of Done
+- Users can localize an LETKF analysis using lon/lat coordinates without
+  hand-rolling distance matrices.
+
+## Relationships
+- Parent epic: FLX-39.
+- Blocked by FLX-19.
+
+---
+
+# filters(local-domain): implement LocalEnKF (patcher-LETKF) and AbstractPatcher protocol
+Draft ID: `FLX-43B`
+## Problem / Request
+Add patcher-based localized LETKF and the `AbstractPatcher` extension point
+per Decision D16.
+
+## Motivation
+Continental / basin-scale domains do not fit a full ensemble × full state in
+device memory. The patcher decomposes the domain into overlapping patches;
+LETKF runs per-patch and blends across overlaps.
+
+## References & Existing Code
+- Design doc / spec:
+  `design_docs/features/localization_inflation.md` §A.2.2,
+  `design_docs/decisions.md` (D16)
+- Wave 2 primitives: `create_patches`, `assign_obs_to_patches`,
+  `blend_patches`
+
+## Implementation Steps
+- [ ] Define `AbstractPatcher` Protocol (`patches`, `stitch`).
+- [ ] Implement an in-house `RegularGridPatcher` consuming the Wave 2
+      primitives.
+- [ ] Implement `LocalEnKF` (a.k.a. patcher-LETKF) as a Layer 2 model.
+- [ ] Document migration path to `geotoolz.patch` once that surface
+      stabilizes.
+
+## Definition of Done
+- A user with a domain that exceeds device memory can run patcher-LETKF
+  end-to-end on the in-house patcher.
+
+## Relationships
+- Parent epic: FLX-38.
+- Blocked by FLX-21 and FLX-23.
+
+---
+
+# state-persistence: implement save_state/load_state and serialization tests
+Draft ID: `FLX-46A`
+## Problem / Request
+Ship the filter / process state persistence helpers required by Decision D15.
+
+## Motivation
+The plumax alert-service use case needs warm-started ensembles within a 5 s
+cold-start budget. Filter state must round-trip to disk.
+
+## References & Existing Code
+- Design doc / spec:
+  `design_docs/features/state_persistence.md`,
+  `design_docs/decisions.md` (D15)
+
+## Implementation Steps
+- [ ] Implement `filterax.save_state(path, state)` and
+      `filterax.load_state(path, like)`.
+- [ ] Add a versioned `b"FAX1"` magic-byte header.
+- [ ] Validate that all static fields on state types are JSON-serializable
+      scalars; raise at construction otherwise.
+- [ ] Round-trip tests for `FilterState`, `ProcessState`, `UKIState`,
+      `AnalysisResult`, `FilterConfig`, `ProcessConfig`.
+
+## Definition of Done
+- Filter state survives a process restart with bit-identical particles and a
+  human-readable version mismatch error on schema bumps.
+
+## Relationships
+- Parent epic: FLX-39.
+
+---
+
 # docs/tests: add advanced filter verification and diagnostic workflows
 Draft ID: `FLX-47`
 ## Problem / Request

--- a/docs/design_docs/issues/wave-5-smoothers-differentiable-integrations.md
+++ b/docs/design_docs/issues/wave-5-smoothers-differentiable-integrations.md
@@ -190,6 +190,68 @@ Add the minimal integration-facing surfaces needed before the final tutorial wav
 
 ---
 
+# integrations(pipekit): verify structural Protocol compatibility with pipekit-cycle
+Draft ID: `FLX-55A`
+## Problem / Request
+Verify (without importing pipekit) that filterax's filter / dynamics / obs-op
+classes satisfy `pipekit_cycle.AnalysisStep`, `ForwardModel`, and
+`ObservationOperator` per Decision D11.
+
+## Motivation
+The plumax / geostack stacks compose filterax into pipekit `Sequential`,
+`Graph`, and `Cycle` pipelines. Structural compatibility must be tested
+explicitly because the duck-typing contract is implicit.
+
+## References & Existing Code
+- Design doc / spec:
+  `design_docs/integrations/pipekit.md`,
+  `design_docs/decisions.md` (D11)
+
+## Implementation Steps
+- [ ] Add an opt-in test module guarded by `pytest.importorskip("pipekit_cycle")`.
+- [ ] Assert `isinstance(filter_instance, pipekit_cycle.AnalysisStep)` for every
+      concrete sequential filter shipped by filterax.
+- [ ] Assert the analogous checks for `ForwardModel` and `ObservationOperator`
+      using a minimal user-supplied dynamics / obs-op.
+- [ ] Document the `StatefulOperator` wrapper recipe in the integration doc
+      (not shipped by filterax).
+
+## Definition of Done
+- A pipekit-cycle user can drop a filterax filter into a `Sequential` graph
+  without writing a custom adapter.
+
+## Relationships
+- Parent epic: FLX-51.
+
+---
+
+# integrations(plumax): worked multi-instrument Tier IV recipe
+Draft ID: `FLX-55B`
+## Problem / Request
+Author the worked-example recipe in `integrations/plumax.md` (already exists)
+into a runnable end-to-end smoke script that exercises `JointObsOperator`,
+`SequentialAssimilation`, `GeoLocalizer`, and the fixed-lag smoother.
+
+## Motivation
+The Tier IV use case is the canonical multi-instrument fusion target. A smoke
+script catches integration regressions before they reach plumax.
+
+## References & Existing Code
+- Design doc / spec: `design_docs/integrations/plumax.md`
+
+## Implementation Steps
+- [ ] Author a synthetic multi-instrument problem in `tests/integration/`.
+- [ ] Run end-to-end: forecast → joint analysis → sequential analysis →
+      fixed-lag smoother → save_state / load_state.
+- [ ] Smoke assertion only (RMSE finite, no NaNs). Numerical correctness lives
+      in the per-component tests.
+
+## Relationships
+- Parent epic: FLX-51.
+- Blocked by FLX-24A, FLX-43A, FLX-46A, FLX-52.
+
+---
+
 # references(zoo): add minimal geo_toolz/xr_assimilate seams and zoo/reference surfaces
 Draft ID: `FLX-56`
 ## Problem / Request

--- a/docs/design_docs/issues/wave-5-smoothers-differentiable-integrations.md
+++ b/docs/design_docs/issues/wave-5-smoothers-differentiable-integrations.md
@@ -190,35 +190,41 @@ Add the minimal integration-facing surfaces needed before the final tutorial wav
 
 ---
 
-# integrations(pipekit): verify structural Protocol compatibility with pipekit-cycle
+# integrations(pipekit): verify wrapper-based Protocol compatibility with pipekit-cycle
 Draft ID: `FLX-55A`
 ## Problem / Request
-Verify (without importing pipekit) that filterax's filter / dynamics / obs-op
-classes satisfy `pipekit_cycle.AnalysisStep`, `ForwardModel`, and
-`ObservationOperator` per Decision D11.
+Verify (without importing pipekit) that the user-side wrappers documented in
+`integrations/pipekit.md` satisfy `pipekit_cycle.AnalysisStep`, `ForwardModel`,
+and `ObservationOperator` per Decision D11.
 
 ## Motivation
 The plumax / geostack stacks compose filterax into pipekit `Sequential`,
-`Graph`, and `Cycle` pipelines. Structural compatibility must be tested
-explicitly because the duck-typing contract is implicit.
+`Graph`, and `Cycle` pipelines. D11 commits to **shape compatibility via
+one-line user wrappers**, not bare-class duck typing — filterax filters expose
+`.analysis(...)`, pipekit wants `__call__(..., *, obs_op, obs_err_cov)`. The
+test target is the wrapper, not the bare filter.
 
 ## References & Existing Code
 - Design doc / spec:
-  `design_docs/integrations/pipekit.md`,
+  `design_docs/integrations/pipekit.md` §4,
   `design_docs/decisions.md` (D11)
 
 ## Implementation Steps
 - [ ] Add an opt-in test module guarded by `pytest.importorskip("pipekit_cycle")`.
-- [ ] Assert `isinstance(filter_instance, pipekit_cycle.AnalysisStep)` for every
-      concrete sequential filter shipped by filterax.
-- [ ] Assert the analogous checks for `ForwardModel` and `ObservationOperator`
-      using a minimal user-supplied dynamics / obs-op.
-- [ ] Document the `StatefulOperator` wrapper recipe in the integration doc
-      (not shipped by filterax).
+- [ ] Re-create the `FilterAsAnalysisStep`, `DynamicsAsForwardModel`, and
+      `FilterCycle` wrappers from `integrations/pipekit.md` in the test file.
+- [ ] Assert `isinstance(FilterAsAnalysisStep(filter_), pipekit_cycle.AnalysisStep)`
+      for every concrete sequential filter shipped by filterax.
+- [ ] Assert the analogous checks for `DynamicsAsForwardModel` and the obs-op
+      (which is structurally identical and needs no wrapper).
+- [ ] Explicitly assert that the bare filter does **not** satisfy
+      `AnalysisStep` (negative test — guards against accidental coupling).
 
 ## Definition of Done
-- A pipekit-cycle user can drop a filterax filter into a `Sequential` graph
-  without writing a custom adapter.
+- A pipekit-cycle user can drop a filterax filter into a `Sequential` graph by
+  writing the ~5-line `FilterAsAnalysisStep` wrapper documented in
+  `integrations/pipekit.md`, and the test suite proves the wrapper satisfies
+  the Protocol.
 
 ## Relationships
 - Parent epic: FLX-51.

--- a/docs/design_docs/research/README.md
+++ b/docs/design_docs/research/README.md
@@ -13,7 +13,8 @@ Background research, prior art audits, and theoretical foundations that informed
 research/
 ├── README.md                  # This file
 ├── research_enskf.md          # Audit of existing kalman_filter/ codebase (~5,000 lines)
-└── ens_kalman_process.md      # EKP theory: math, numerical requirements, process zoo, BLR connection
+├── ens_kalman_process.md      # EKP theory: math, numerical requirements, process zoo, BLR connection
+└── operational_da.md          # Streaming / alert-service patterns; cold-start budget; commitments
 ```
 
 ## Reading Order
@@ -22,9 +23,12 @@ research/
 
 2. **[ens_kalman_process.md](ens_kalman_process.md)** — deep-dive on Ensemble Kalman Processes (EKI, EKS, UKI, ETKI, GNKI). Covers mathematical formulations, numerical requirements (ensemble size, scheduling, constraints), process zoo comparison tables, JAX API design, example applications, connection to the Bayesian Learning Rule, and gaussx integration.
 
+3. **[operational_da.md](operational_da.md)** — operational tail of the research-to-production arc: alert services, reanalysis, online retraining. Cold-start budget, streaming patterns, what filterax commits to vs. punts to deployment.
+
 ## How These Relate to the Design Docs
 
 | Research file | Informs | Key content |
 |---|---|---|
 | `research_enskf.md` | `api/components.md` (filters, smoothers), `boundaries.md` (gap analysis) | What exists today, what needs formalization |
 | `ens_kalman_process.md` | `api/components.md` (processes, schedulers), `architecture.md` (gaussx integration), `boundaries.md` (BLR decision tree) | Math behind each process, when to use which |
+| `operational_da.md` | `features/state_persistence.md`, `integrations/plumax.md`, `features/multi_instrument.md` | Why the new ADRs D11–D16 exist; latency / streaming concerns |

--- a/docs/design_docs/research/operational_da.md
+++ b/docs/design_docs/research/operational_da.md
@@ -1,0 +1,169 @@
+---
+status: draft
+version: 0.1.0
+---
+
+# Research — operational data assimilation patterns
+
+**Subject:** Sketches of how filterax fits into latency-sensitive, streaming, and online DA settings — the operational tail of the research-to-production arc.
+
+**Status:** Research note, not API spec. The concrete API commitments live in `features/`, `integrations/`, and `decisions.md`.
+
+---
+
+## 1  Why this doc exists
+
+filterax's design is shaped by both research workflows (notebooks, papers, sweeps) and operational workflows (alert services, scheduled cycles, retraining loops). The research side is well-covered by `vision.md` and the feature docs; the operational side is more dispersed. This note collects the operational requirements in one place and traces them to filterax's design commitments.
+
+---
+
+## 2  Operational workflows of interest
+
+### 2.1  Methane attribution alert service (plumax)
+
+A FastAPI service ingests satellite L2 retrievals as they land, runs an ensemble DA cycle, and emits an alert payload (location, source rate estimate, uncertainty) within a fixed latency budget.
+
+| Characteristic | Value |
+|---|---|
+| Latency budget | ≤5 s per alert |
+| Trigger | New L2 retrieval available on the catalog |
+| State carrier | `coordax.Array` or `GeoTensor` (coordinate-aware) |
+| State dimension | 20 (Tier I Gaussian plume) — 10⁴ (Tier III gridded transport) |
+| Ensemble size | 50–1000 |
+| Observation dimension | 100–1000 pixels per overpass |
+| Restart frequency | Every new overpass; warm-started from disk |
+
+filterax design responses:
+
+- `save_state` / `load_state` for warm-start (D15, `features/state_persistence.md`).
+- `JointObsOperator` for multi-instrument fusion (D12, `features/multi_instrument.md`).
+- `GeoLocalizer` for geographic localization (D14, `features/localization_inflation.md`).
+- `CarrierAdapter` for coordinate-aware particles (D13, `integrations/geostack.md`).
+
+### 2.2  Continental reanalysis
+
+A scheduled job processes a year of satellite observations as a chain of cycles, producing a reanalysis dataset for downstream science. Latency does not matter; throughput, reproducibility, and post-hoc smoothing do.
+
+| Characteristic | Value |
+|---|---|
+| Latency budget | Hours per cycle is fine |
+| State dimension | 10⁴–10⁶ (continental grid) |
+| Ensemble size | 200–500 |
+| Smoother | Fixed-lag or full RTS over week-scale windows |
+| Output | xarray / zarr dataset of analysis + smoother + uncertainty |
+
+filterax design responses:
+
+- `LocalEnKF` (patcher-LETKF) for domain decomposition (D16).
+- Smoothers as a first-class deliverable, not an extension (D8, `features/smoothers.md`).
+- xarray orchestration via `xr_assimilate` — outside filterax (`boundaries.md`).
+
+### 2.3  Online retraining of neural surrogates
+
+A neural RTM is continuously retrained against new L1 radiance as it lands. The training signal is observation-space log-likelihood through the full filter.
+
+| Characteristic | Value |
+|---|---|
+| Loss | `-log_likelihood` over a rolling time window |
+| Gradient path | RTM params → obs operator → analysis → log-likelihood |
+| Training cadence | Daily or per-batch |
+| Checkpoint frequency | After each batch |
+
+filterax design responses:
+
+- Differentiability by construction (D9, `features/differentiable_da.md`).
+- Filter state checkpointing (D15).
+- No special "training mode" — `jax.grad` on a filter call is the API.
+
+---
+
+## 3  Cross-cutting concerns
+
+### 3.1  Cold-start budget
+
+The ≤5 s budget breaks down approximately as:
+
+| Cost | Budget |
+|------|--------|
+| Process start + Python imports | ~1 s |
+| `load_state` from disk | ~0.1 s |
+| JIT-compile the analysis graph | 1–3 s (first call only) |
+| Actual analysis | < 0.5 s for 200-member, 10⁴-state ensemble |
+
+JIT compilation is the dominant cost on cold start. Mitigations:
+
+- **Persistent JIT cache.** `jax.experimental.compilation_cache.set_cache_dir(...)` keeps the compiled XLA computation on disk across process restarts.
+- **AoT compilation.** `jax.jit(fn).lower(args).compile()` produces a compiled object that can be pickled and reloaded. Experimental but increasingly stable.
+- **Long-lived workers.** If the deployment can keep a Python process alive (uvicorn workers, long-running pods), JIT only happens once.
+
+filterax doesn't ship a recipe for any of these — they're deployment concerns. We commit to *not making them harder*: every JIT-able path through filterax is a single static-shape function, no per-overpass recompilation.
+
+### 3.2  Streaming observations
+
+The alert service consumes observations one at a time as they land. Each analysis is independent (modulo warm-state). The pattern is:
+
+```
+loop:
+    wait for new overpass
+    load filter state from disk
+    propagate ensemble through dynamics
+    analysis(forecast, new_obs, op, noise)
+    save filter state to disk
+    emit alert
+```
+
+filterax supports this pattern directly via the `analysis` + `save_state` / `load_state` surfaces. There is no "streaming filter" abstraction — the streaming loop is user-owned.
+
+For pipekit integration, the streaming loop wraps a filterax filter in `StatefulOperator` (`integrations/pipekit.md` §4.3). pipekit's `Cycle` then drives the loop.
+
+### 3.3  Async observation fetching
+
+Real alert services fetch L1B / L2 data from cloud storage asynchronously. filterax has nothing to say about async — every filterax function is sync, pure-JAX. The async fetch happens in user code; filterax sees only the resulting array.
+
+### 3.4  Hybrid ensemble-variational for tight latency
+
+For latency-critical applications (alert service), pure ensemble methods are usually fast enough at moderate ensemble sizes (~100 members). When they're not, the operational pattern is:
+
+- Use the ensemble for **background covariance** (flow-dependent, captures uncertainty).
+- Run L-BFGS or another gradient method for the analysis update (deterministic, fast).
+
+This is hybrid EnVar; it crosses the boundary between filterax and `vardax`. We don't ship it. The open-questions section of `boundaries.md` tracks the eventual cross-library design.
+
+---
+
+## 4  What filterax commits to and what it doesn't
+
+### Commitments
+
+- **Pure JAX analysis path.** No Python control flow per analysis step; everything inside `jax.jit`.
+- **Serializable state.** D15 — `save_state` / `load_state` round-trip every state type.
+- **Static-shape API.** Observation vector shape is fixed at JIT time; masking handled via `MaskedObsOperator` with dynamic mask.
+- **No hidden mutation.** Every filter is pure; warm-start from disk is bit-identical.
+
+### Non-commitments
+
+- **No latency guarantees.** filterax does not measure or budget cold-start time. That's deployment-side.
+- **No async API.** Sync, pure-JAX. Async happens outside.
+- **No metric emission.** Logs, traces, Prometheus metrics — all user-owned.
+- **No "operational mode."** There's no flag that flips filterax into operational behavior. The same library serves notebooks and alert services.
+
+---
+
+## 5  Open questions
+
+1. **AoT compilation for filter graphs.** `jax.experimental.serialize_executable` is maturing. When stable, filterax could ship a recipe for compiling an analysis graph once and reloading per process.
+2. **Static-typed observation schema.** A `JointObsOperator` over a fixed instrument tuple has a fixed observation shape. Could filterax provide a `@filter_for(joint_op)` decorator that pre-computes shapes? Defer until pressure is concrete.
+3. **Distributed analysis.** Patcher-LETKF across multiple devices via `jax.pmap` or `shard_map`. Defer to Wave 4+ once the in-house patcher lands.
+
+These all live in the research column for now. They become design changes only when a downstream consumer (plumax, geostack) puts concrete pressure on them.
+
+---
+
+## 6  References
+
+- `vision.md` — motivating use case and downstream pressures
+- `integrations/plumax.md` — worked Tier IV recipe
+- `features/state_persistence.md` — full serialization contract
+- `features/multi_instrument.md` — fusion patterns
+- `features/differentiable_da.md` — gradient pipe for neural surrogates
+- pipekit `pipekit-train` design docs — analogue patterns for training loops

--- a/docs/design_docs/vision.md
+++ b/docs/design_docs/vision.md
@@ -37,6 +37,31 @@ ekalmX provides all three modes in a single JAX/Equinox library, with shared ens
 
 ---
 
+## Motivating Downstream Use Case
+
+The concrete pressure on filterax's design comes from a multi-instrument operational pipeline: **methane plume attribution from satellite observations** (the `plumax` + `geostack` stack).
+
+A Tier IV attribution event fuses observations from heterogeneous satellites — TROPOMI (24 h global revisit), EMIT (ISS cadence, hyperspectral), GHGSat (tasked, high-resolution) — into a joint posterior over source rates, source positions, wind, background concentrations, and per-instrument biases. The state vector mixes order-10 dynamical parameters with order-10⁴ gridded transport-model fields; observations arrive at native resolutions with different noise characteristics, averaging kernels, and overpass times.
+
+Concrete pressure this puts on filterax:
+
+| Requirement | Design response |
+|-------------|-----------------|
+| Heterogeneous, time-staggered multi-instrument obs | `JointObsOperator` + `SequentialAssimilation` (D12, `features/multi_instrument.md`) |
+| Geographic-distance localization (not grid-index) | `GeoLocalizer` + pyproj-built `LocalFrame` (D14, `features/localization_inflation.md`) |
+| Large domains that don't fit in device memory | Patcher-LETKF, `AbstractPatcher` protocol (D16) |
+| Coordinate-aware particles (CRS, dims, time) | `CarrierAdapter` for `coordax.Array` / `GeoTensor` (D13, `integrations/geostack.md`) |
+| ≤5 s cold-start for alert service | Pickleable filter state, `save_state` / `load_state` (D15, `features/state_persistence.md`) |
+| Multi-day post-hoc event reconstruction | Fixed-lag + RTS smoothers prioritized (D8, Wave 5) |
+| Differentiable RTM in observation operator | Differentiable-by-construction (D9, `features/differentiable_da.md`) |
+| Slot into pipekit `Cycle` / `Graph` pipelines | Structural Protocol satisfaction (D11, `integrations/pipekit.md`) |
+
+filterax does not implement plumax or geostack. It implements the statistical machinery they need, with care to leave clean integration seams.
+
+See `integrations/plumax.md` for the worked API sketch.
+
+---
+
 ## Design Principles
 
 1. **Equinox-native** — All components are `eqx.Module` pytrees. No mutable state, no side effects. Fully compatible with `jax.jit`, `jax.grad`, `eqx.filter_vmap`, and the equinox ecosystem (optimistix, diffrax, lineax, gaussx).


### PR DESCRIPTION
## Summary

Synthesizes pressures from `pipekit-cycle` protocols, the plumax / geostack operational use case, and the geographic / streaming requirements surfaced in the `research_journal_v2` notes into the existing wave-based design. **No source code, tests, or wave boundaries change** — pure design augmentation.

### Six new ADRs (D11–D16)

| # | Decision |
|---|---|
| **D11** | filterax classes **structurally satisfy** `pipekit_cycle.{ForwardModel, ObservationOperator, AnalysisStep}` Protocols — but filterax does not import pipekit. Compatibility is duck-typed via `@runtime_checkable`. |
| **D12** | Multi-instrument fusion ships **both** surfaces: `JointObsOperator(ops, noise_covs)` (one analysis, block-diagonal R) and `SequentialAssimilation(filter)` (loop analyses for time-staggered overpasses). |
| **D13** | `FilterState.particles` stays a bare JAX array. Coordinate-aware carriers (`coordax.Array`, `GeoTensor`) plug in via a thin `CarrierAdapter` (flatten ↔ unflatten); metadata lives outside the math layer. |
| **D14** | Geographic localization owned by filterax: `GeoLocalizer(coords, frame, radius_km)` with a pyproj-built `LocalFrame` as static metadata. JIT path stays pure JAX. |
| **D15** | `FilterState` / `ProcessState` / `UKIState` / etc. are `eqx.tree_serialise_leaves`-compatible. Adds `save_state` / `load_state` helpers with a `b"FAX1"` magic-byte header. |
| **D16** | Patcher-based localized DA owned by filterax. Wave 2 ships in-house primitives + `LocalEnKF`; Wave 4 adds `AbstractPatcher` extension point; migrate to `geotoolz.patch` once stable. |

### Seven new docs

- `integrations/README.md`, `integrations/pipekit.md`, `integrations/plumax.md`, `integrations/geostack.md`
- `features/multi_instrument.md`, `features/state_persistence.md`
- `research/operational_da.md`

### Touched docs

`vision.md`, `architecture.md`, `boundaries.md`, `decisions.md`, `README.md`, four `features/*.md` cross-references, three wave issue lists (six new tasks: FLX-24A, FLX-43A, FLX-43B, FLX-46A, FLX-55A, FLX-55B), and `research/README.md`.

### Inputs reviewed

- `jej_vc_snippets/design_docs/filterX/*` — original ekalmX design (already imported in PR #71; this revision adds the integration story)
- `pipekit` — `pipekit-cycle` Protocols, `Operator`/`Sequential`/`Graph`/`StatefulOperator` patterns, ConfigMixin discipline
- `research_journal_v2` — geostack master plan, plumax Tier IV state vector + multi-instrument fusion, RTM design, operational attribution requirements

## Test plan

- [ ] Render `mkdocs serve` and confirm all internal links resolve (new `integrations/*` cross-references, ADR anchors in `decisions.md`, updated wave issue IDs).
- [ ] Skim `decisions.md` D11–D16 for technical correctness against the existing D1–D10.
- [ ] Confirm `vision.md` "Motivating Downstream Use Case" reflects the intended plumax/geostack pressures.
- [ ] Confirm `integrations/plumax.md` API sketch matches the Tier IV plan in `research_journal_v2`.
- [ ] No source code changed: `make test` / `make lint` / `make typecheck` not required for this PR.

https://claude.ai/code/session_01JL6ivDyWHmW71h3YfsAxQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JL6ivDyWHmW71h3YfsAxQU)_