### PR TITLE
feat(wave-5.B): differentiable scan loop + rank-N_y filter spectrum fix

### DIFF
--- a/src/filterax/__init__.py
+++ b/src/filterax/__init__.py
@@ -27,6 +27,9 @@ from filterax._src._types import (
     SmoothingResult as SmoothingResult,
     UKIState as UKIState,
 )
+from filterax._src.differentiable import (
+    differentiable_assimilate as differentiable_assimilate,
+)
 from filterax._src.gain import kalman_gain as kalman_gain
 from filterax._src.inflation import (
     inflate_adaptive as inflate_adaptive,

--- a/src/filterax/_src/differentiable.py
+++ b/src/filterax/_src/differentiable.py
@@ -27,20 +27,6 @@ well with ``jax.grad``:
 
 We validate the stochastic-component constraint at call time so users
 get a clear error instead of silently noisy gradients.
-
-.. warning::
-    ``ETKF`` / ``EnSRF`` / ``ESTKF`` / ``LETKF`` / ``ETKF_Livings`` all
-    route through an internal :func:`jax.numpy.linalg.eigh` of a matrix
-    with structurally-degenerate eigenvalues (the rank-``N_y``
-    transform precision has ``N_e − N_y`` repeated eigenvalues). JAX's
-    ``eigh`` AD returns ``NaN`` for repeated eigenvalues, so reverse-
-    mode gradients through these filters underflow to ``NaN`` when
-    ``N_e`` is meaningfully larger than ``N_y``. **Use
-    :class:`filterax.filters.EnSRF_Serial`** for differentiable
-    training — it uses scalar-per-observation updates with no
-    eigendecomposition and is gradient-stable at any ``N_e``. Fixing
-    the eigh-based filters via a rank-``N_y`` SVD reformulation is
-    tracked in issue #82.
 """
 
 from __future__ import annotations

--- a/src/filterax/_src/differentiable.py
+++ b/src/filterax/_src/differentiable.py
@@ -82,7 +82,8 @@ def _reject_stochastic_components(
         raise ValueError(
             "AdditiveInflator injects PRNG draws that break smooth "
             "gradients. Use MultiplicativeInflator / RTPS / RTPP for "
-            "differentiable training — see §5.5 of differentiable_da.md."
+            "differentiable training — see "
+            "design_docs/features/differentiable_da.md §5.5."
         )
 
 
@@ -144,6 +145,17 @@ def differentiable_assimilate(
             f"got {observations.shape[0]} and {obs_times.shape[0]}."
         )
 
+    # ``lax.scan`` requires the carry's input and output dtypes to match
+    # exactly. ``t_prev`` enters the carry from ``t0`` and exits it from
+    # the per-step ``obs_times`` element, so cast both to a common dtype
+    # up front — otherwise float32 ensembles with float64 (or integer)
+    # ``obs_times`` raise at trace time even though the L2 Python loop
+    # would accept that combination.
+    t0_arr = jnp.asarray(t0)
+    time_dtype = jnp.result_type(t0_arr, obs_times)
+    t0_arr = t0_arr.astype(time_dtype)
+    obs_times = obs_times.astype(time_dtype)
+
     def step(
         carry: tuple[Float[Array, "N_e N_x"], Float[Array, ""]],
         inputs: tuple[Float[Array, " N_y"], Float[Array, ""]],
@@ -173,7 +185,7 @@ def differentiable_assimilate(
         )
 
     step_fn = jax.checkpoint(step) if checkpoint else step
-    init_carry = (init_ensemble, jnp.asarray(t0, dtype=init_ensemble.dtype))
+    init_carry = (init_ensemble, t0_arr)
     (final_particles, _), (forecasts, analyses, logps) = jax.lax.scan(
         step_fn, init_carry, (observations, obs_times)
     )

--- a/src/filterax/_src/differentiable.py
+++ b/src/filterax/_src/differentiable.py
@@ -1,0 +1,199 @@
+"""Differentiable assimilation loop (Wave 5.B).
+
+filterax filters are differentiable by construction (Decision D9 +
+``design_docs/features/differentiable_da.md``) — every analysis step
+is a pure JAX computation that ``jax.grad`` and ``jax.jit`` already
+compose with. What this module adds is the *scan + remat* idiom the
+design doc calls out: a fixed-shape :func:`jax.lax.scan` over a stacked
+observation history, optionally wrapping the step in
+:func:`jax.checkpoint` so reverse-mode AD over long ``T`` doesn't blow
+out memory.
+
+The L2 :class:`filterax.ETKF` / :class:`filterax.EnSRF` / … wrappers
+use a Python ``for`` loop instead. That works under ``jax.grad`` for
+short ``T`` but unrolls into one giant traced graph at compile time and
+doesn't compose with ``jax.checkpoint``. Use
+:func:`differentiable_assimilate` when training through the filter.
+
+The design doc is explicit about which filter / inflator flavours play
+well with ``jax.grad``:
+
+* **Filters** — use deterministic square-root variants (``ETKF``,
+  ``EnSRF``, ``ESTKF``, ``LETKF``, ``EnSRF_Serial``). Stochastic ones
+  (``StochasticEnKF``, ``ETKF_Livings``) inject per-step PRNG draws
+  that break smooth gradients.
+* **Inflators** — use ``MultiplicativeInflator`` / ``RTPS`` / ``RTPP``.
+  ``AdditiveInflator`` is stochastic.
+
+We validate the stochastic-component constraint at call time so users
+get a clear error instead of silently noisy gradients.
+
+.. warning::
+    ``ETKF`` / ``EnSRF`` / ``ESTKF`` / ``LETKF`` / ``ETKF_Livings`` all
+    route through an internal :func:`jax.numpy.linalg.eigh` of a matrix
+    with structurally-degenerate eigenvalues (the rank-``N_y``
+    transform precision has ``N_e − N_y`` repeated eigenvalues). JAX's
+    ``eigh`` AD returns ``NaN`` for repeated eigenvalues, so reverse-
+    mode gradients through these filters underflow to ``NaN`` when
+    ``N_e`` is meaningfully larger than ``N_y``. **Use
+    :class:`filterax.filters.EnSRF_Serial`** for differentiable
+    training — it uses scalar-per-observation updates with no
+    eigendecomposition and is gradient-stable at any ``N_e``. Fixing
+    the eigh-based filters via a rank-``N_y`` SVD reformulation is
+    tracked in issue #82.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+from jaxtyping import Array, Float
+
+from filterax._src._protocols import (
+    AbstractDynamics,
+    AbstractInflator,
+    AbstractObsOperator,
+    AbstractSequentialFilter,
+)
+from filterax._src._types import AssimilationResult
+
+
+def _forecast(
+    dynamics: AbstractDynamics,
+    particles: Float[Array, "N_e N_x"],
+    t0: Float[Array, ""],
+    t1: Float[Array, ""],
+) -> Float[Array, "N_e N_x"]:
+    """vmap dynamics over ensemble members — mirrors models._forecast."""
+    return eqx.filter_vmap(lambda x: dynamics(x, t0, t1))(particles)
+
+
+def _reject_stochastic_components(
+    filter_: AbstractSequentialFilter,
+    inflator: AbstractInflator | None,
+) -> None:
+    """Refuse filter / inflator flavours whose gradients are non-smooth.
+
+    Deferred imports avoid a module-level cycle with
+    :mod:`filterax._src.sequential` and :mod:`filterax._src.inflators`.
+    """
+    from filterax._src.inflators import AdditiveInflator
+    from filterax._src.sequential import ETKF_Livings, StochasticEnKF
+
+    if isinstance(filter_, (StochasticEnKF, ETKF_Livings)):
+        raise ValueError(
+            f"{type(filter_).__name__} uses per-step PRNG draws that break "
+            "smooth gradients under jax.grad. Use a deterministic square-root "
+            "filter (ETKF, EnSRF, ESTKF, EnSRF_Serial, LETKF) for "
+            "differentiable training — see "
+            "design_docs/features/differentiable_da.md §5.2."
+        )
+    if isinstance(inflator, AdditiveInflator):
+        raise ValueError(
+            "AdditiveInflator injects PRNG draws that break smooth "
+            "gradients. Use MultiplicativeInflator / RTPS / RTPP for "
+            "differentiable training — see §5.5 of differentiable_da.md."
+        )
+
+
+def differentiable_assimilate(
+    filter_: AbstractSequentialFilter,
+    dynamics: AbstractDynamics,
+    obs_op: AbstractObsOperator,
+    init_ensemble: Float[Array, "N_e N_x"],
+    observations: Float[Array, "T N_y"],
+    obs_times: Float[Array, " T"],
+    obs_noise: lx.AbstractLinearOperator,
+    *,
+    inflator: AbstractInflator | None = None,
+    t0: float | Float[Array, ""] = 0.0,
+    checkpoint: bool = False,
+    **analysis_extra: Any,
+) -> AssimilationResult:
+    r"""Scan-based assimilation loop suitable for ``jax.grad`` / ``jax.jit``.
+
+    Drop-in replacement for the L2 ``model.assimilate(...)`` Python loop
+    when the caller needs a single fused XLA ``While`` (large ``T``,
+    short compile, optional gradient checkpointing). Observations and
+    timestamps are stacked along a leading time axis so the loop body
+    has a static shape.
+
+    Args:
+        filter_: Deterministic L1 filter (``ETKF``, ``EnSRF``, ``ESTKF``,
+            ``EnSRF_Serial``, or ``LETKF``). Stochastic filters raise.
+        dynamics: Forward model applied with :func:`equinox.filter_vmap`
+            over the ensemble.
+        obs_op: Observation operator ``H``.
+        init_ensemble: Prior ensemble ``(Nₑ, Nₓ)``.
+        observations: Stacked obs ``(T, Nᵧ)``.
+        obs_times: Stacked timestamps ``(T,)``. The forecast for window
+            ``t`` propagates from ``obs_times[t-1]`` (or ``t0`` when
+            ``t == 0``) to ``obs_times[t]``.
+        obs_noise: Observation error covariance ``R``.
+        inflator: Optional deterministic inflator
+            (``MultiplicativeInflator`` / ``RTPS`` / ``RTPP``).
+            ``AdditiveInflator`` raises.
+        t0: Starting time used for the first forecast window. Default 0.
+        checkpoint: When ``True``, wrap the scan body with
+            :func:`jax.checkpoint`. Reduces backward-pass memory from
+            ``O(T Nₑ Nₓ)`` to ``O(√T Nₑ Nₓ)`` at 2–3× compute cost — see
+            §5.1 of the differentiable-DA design doc.
+        **analysis_extra: Forwarded to ``filter_.analysis(...)``. Use
+            this for filters that need extra context (``LETKF`` takes
+            ``state_coords`` / ``obs_coords`` here).
+
+    Returns:
+        :class:`AssimilationResult` with the same fields as
+        ``L2.assimilate(...)``. ``log_likelihoods`` is always populated
+        because every deterministic filter returns one.
+    """
+    _reject_stochastic_components(filter_, inflator)
+    if observations.shape[0] != obs_times.shape[0]:
+        raise ValueError(
+            "observations and obs_times must have the same leading axis; "
+            f"got {observations.shape[0]} and {obs_times.shape[0]}."
+        )
+
+    def step(
+        carry: tuple[Float[Array, "N_e N_x"], Float[Array, ""]],
+        inputs: tuple[Float[Array, " N_y"], Float[Array, ""]],
+    ) -> tuple[
+        tuple[Float[Array, "N_e N_x"], Float[Array, ""]],
+        tuple[Float[Array, "N_e N_x"], Float[Array, "N_e N_x"], Float[Array, ""]],
+    ]:
+        particles, t_prev = carry
+        obs_t, t_now = inputs
+        forecast = _forecast(dynamics, particles, t_prev, t_now)
+        result = filter_.analysis(forecast, obs_t, obs_op, obs_noise, **analysis_extra)
+        analysis_particles = result.particles
+        if inflator is not None:
+            analysis_particles = inflator(analysis_particles, forecast)
+        # ``log_likelihood`` is typed ``Array | None`` on the protocol but
+        # is populated by every deterministic filter we accept. The
+        # Python-level guard is resolved at trace time, so when a filter
+        # ever returns ``None`` we fall back to NaN rather than feeding
+        # ``None`` into ``lax.scan``.
+        log_lik = result.log_likelihood
+        if log_lik is None:
+            log_lik = jnp.full((), jnp.nan, dtype=forecast.dtype)
+        return (analysis_particles, t_now), (
+            forecast,
+            analysis_particles,
+            log_lik,
+        )
+
+    step_fn = jax.checkpoint(step) if checkpoint else step
+    init_carry = (init_ensemble, jnp.asarray(t0, dtype=init_ensemble.dtype))
+    (final_particles, _), (forecasts, analyses, logps) = jax.lax.scan(
+        step_fn, init_carry, (observations, obs_times)
+    )
+    return AssimilationResult(
+        particles=final_particles,
+        forecast_history=forecasts,
+        analysis_history=analyses,
+        log_likelihoods=logps,
+    )

--- a/src/filterax/_src/sequential.py
+++ b/src/filterax/_src/sequential.py
@@ -55,12 +55,6 @@ from filterax._src.statistics import ensemble_anomalies, ensemble_mean
 
 ObsCallable = Callable[[Float[Array, " N_x"]], Float[Array, " N_y"]]
 
-# Floor applied to eigenvalues of the (Nₑ, Nₑ) transform precision before
-# inversion / square root. The eigenvalues are mathematically bounded
-# below by Nₑ − 1 (≥ 2 for any valid ensemble), so a tiny absolute floor
-# only kicks in if a near-zero negative slipped through due to round-off.
-_EIG_FLOOR: float = 1e-12
-
 
 def _apply_obs_op(
     obs_op: AbstractObsOperator | ObsCallable,
@@ -70,31 +64,76 @@ def _apply_obs_op(
     return jax.vmap(obs_op)(particles)
 
 
-def _symmetrize(matrix: Float[Array, "N N"]) -> Float[Array, "N N"]:
-    """Return ``½ (M + Mᵀ)`` — kills accumulated antisymmetric round-off."""
-    return 0.5 * (matrix + matrix.T)
+def _etkf_inner_spectrum(
+    obs_anom: Float[Array, "K N_y"],
+    R_inv_Y: Float[Array, "K N_y"],
+) -> tuple[Float[Array, " N_y"], Float[Array, "K N_y"]]:
+    r"""Rank-``Nᵧ`` spectrum of the inner product ``Y′ R⁻¹ Y′ᵀ``.
 
+    ``Y′ R⁻¹ Y′ᵀ = U_y diag(λ_i) U_yᵀ`` with ``U_y ∈ ℝ^{K × Nᵧ}`` an
+    orthonormal basis for the column span of ``Y′`` (the only directions
+    where the outer product has non-trivial action). The remaining
+    ``K − Nᵧ`` eigenvalues are all zero; they correspond to a degenerate
+    null subspace that downstream matrix-function evaluations short-
+    circuit through ``g(K_base)`` and never need explicit eigenvectors
+    for.
 
-def _transform_eig(
-    obs_anom: Float[Array, "N_e N_y"],
-    R_inv_Y: Float[Array, "N_e N_y"],
-    N_e: int,
-) -> tuple[Float[Array, " N_e"], Float[Array, "N_e N_e"]]:
-    r"""Eigendecomposition of the ETKF transform precision.
+    Computed via thin QR + a small ``(Nᵧ, Nᵧ)`` eigh:
 
-    ``C̃ = (Nₑ − 1) I + Y′ R⁻¹ Y′ᵀ ∈ ℝ^{Nₑ×Nₑ}``
+    1. ``Y′ = Q R_qr`` (thin QR; ``Q ∈ ℝ^{K × Nᵧ}``, ``R_qr ∈ ℝ^{Nᵧ × Nᵧ}``).
+    2. ``M_y = Qᵀ (Y′ R⁻¹) R_qrᵀ = R_qr R⁻¹ R_qrᵀ`` (symmetric PSD,
+       ``Nᵧ × Nᵧ``).
+    3. ``M_y = V_M diag(λ_i) V_Mᵀ`` via eigh on the small matrix.
+    4. ``U_y = Q V_M``.
 
-    Symmetrises ``C̃`` to absorb floating-point antisymmetry, calls
-    :func:`jax.numpy.linalg.eigh`, and clamps eigenvalues to a tiny
-    positive floor so the downstream ``1/λ`` and ``√λ`` stay finite.
+    This avoids the ``(K, K)`` eigh of the design-doc form
+    ``(Nₑ − 1) I + Y′ R⁻¹ Y′ᵀ`` whose ``K − Nᵧ`` structurally-repeated
+    eigenvalues give ``NaN`` reverse-mode gradients in JAX (issue #82).
 
-    Returns ``(λ, U)`` where ``C̃ = U diag(λ) Uᵀ`` and all ``λ_k > 0``.
-    Cost ``O(Nₑ³)``.
+    Used in two places:
+
+    * ETKF-style filters with ``K = Nₑ`` (``ETKF``, ``EnSRF``,
+      ``ETKF_Livings``; ``LETKF`` per-grid-point).
+    * ESTKF with ``K = Nₑ − 1`` (reduced subspace).
+
+    Assumes ``Nᵧ ≤ K``; gradient-stable when ``Y′`` has full column
+    rank (i.e. observations are linearly independent across the
+    ensemble), which is the typical ensemble-filtering setting.
     """
-    C_tilde = (N_e - 1) * jnp.eye(N_e) + einx.dot("e a, f a -> e f", obs_anom, R_inv_Y)
-    eigvals, eigvecs = jnp.linalg.eigh(_symmetrize(C_tilde))
-    eigvals = jnp.maximum(eigvals, _EIG_FLOOR)
-    return eigvals, eigvecs
+    Q, R_qr = jnp.linalg.qr(obs_anom)  # Q: (K, N_y), R_qr: (N_y, N_y)
+    # Qᵀ (Y′ R⁻¹) = R_qr R⁻¹ (since Qᵀ Y′ = R_qr).
+    R_qr_R_inv = einx.dot("e a, e b -> a b", Q, R_inv_Y)  # (N_y, N_y)
+    M_y = einx.dot("a b, c b -> a c", R_qr_R_inv, R_qr)  # (N_y, N_y)
+    M_y = 0.5 * (M_y + jnp.swapaxes(M_y, -1, -2))
+    eigvals, V_M = jnp.linalg.eigh(M_y)
+    # ``M_y`` is PSD by construction; tiny negative round-off is clipped.
+    eigvals = jnp.maximum(eigvals, 0.0)
+    U_y = einx.dot("e a, a b -> e b", Q, V_M)
+    return eigvals, U_y
+
+
+def _apply_ctilde_func(
+    U_y: Float[Array, "K N_y"],
+    g_diff: Float[Array, " N_y"],
+    g_base: Float[Array, ""],
+    v: Float[Array, "K ..."],
+) -> Float[Array, "K ..."]:
+    r"""Apply ``g(C̃)`` to ``v`` via the rank-``Nᵧ`` correction form.
+
+    ``g(C̃) = g_base · I + U_y diag(g_diff) U_yᵀ``
+
+    with ``g_diff[i] = g((Nₑ − 1) + λ_i) − g_base`` and
+    ``g_base = g(Nₑ − 1)``. The caller supplies the precomputed
+    differences so the same ``U_y`` / ``λ`` decomposition can be reused
+    across multiple matrix functions in one analysis step.
+
+    ``v`` is a vector ``(K,)`` or matrix ``(K, …)``; the leading axis is
+    the one ``g(C̃)`` acts on.
+    """
+    Ut_v = einx.dot("e a, e ... -> a ...", U_y, v)
+    scaled = einx.multiply("a, a ... -> a ...", g_diff, Ut_v)
+    correction = einx.dot("e a, a ... -> e ...", U_y, scaled)
+    return g_base * v + correction
 
 
 class StochasticEnKF(AbstractSequentialFilter, strict=True):
@@ -219,28 +258,24 @@ class ETKF(AbstractSequentialFilter, strict=True):
         # for DiagonalLinearOperator, Toeplitz, etc.).
         R_inv_Y = gaussx.solve_rows(obs_noise, obs_anom)  # (Nₑ, Nᵧ)
 
-        eigvals, eigvecs = _transform_eig(obs_anom, R_inv_Y, N_e)
+        # Rank-Nᵧ spectrum of Y′ R⁻¹ Y′ᵀ via QR + small eigh; avoids the
+        # gradient-NaN trap of an eigh on the full (Nₑ, Nₑ) C̃ matrix.
+        eigvals, U_y = _etkf_inner_spectrum(obs_anom, R_inv_Y)
 
-        # Symmetric inverse square root: Wₐ = U diag(√((Nₑ−1)/λ)) Uᵀ.
-        # ``eigvecs`` is U; columns are eigenvectors, so eigvecs[:, k] is the
-        # k-th eigenvector. Equivalently, U[i, k] is the i-th component of
-        # the k-th eigenvector — when we sum over the FIRST axis we apply Uᵀ.
-        inv_lambda = 1.0 / eigvals
-        sqrt_scale = jnp.sqrt((N_e - 1) * inv_lambda)
+        # T = C̃⁻¹ = (1/(Nₑ−1)) I + U_y diag(inv_diff) U_yᵀ.
+        inv_base = jnp.asarray(1.0 / (N_e - 1), dtype=anom.dtype)
+        inv_diff = 1.0 / ((N_e - 1) + eigvals) - inv_base
+        # Wₐ = √((Nₑ−1) C̃⁻¹) = I + U_y diag(sqrt_diff) U_yᵀ.
+        sqrt_base = jnp.asarray(1.0, dtype=anom.dtype)
+        sqrt_diff = jnp.sqrt((N_e - 1) / ((N_e - 1) + eigvals)) - sqrt_base
 
-        # y = Y′ R⁻¹ v ∈ ℝ^{Nₑ}.
+        # Mean: w̄ = T (Y′ R⁻¹ v); then mean_correction = w̄ᵀ X′.
         Y_R_inv_v = einx.dot("e y, y -> e", R_inv_Y, innovation)
-        # w̄ = T y = U diag(1/λ) Uᵀ y. Sum the FIRST axis of U for Uᵀ.
-        Ut_y = einx.dot("e a, e -> a", eigvecs, Y_R_inv_v)
-        w_bar = einx.dot("e a, a -> e", eigvecs, inv_lambda * Ut_y)
-
-        # Mean update: x̄_a = x̄ + Σ_k w̄[k] X′[k, :].
+        w_bar = _apply_ctilde_func(U_y, inv_diff, inv_base, Y_R_inv_v)
         mean_correction = einx.dot("e, e x -> x", w_bar, anom)
 
-        # Wₐ X′ = U diag(sqrt_scale) Uᵀ X′ — three factored matmuls.
-        Ut_anom = einx.dot("e a, e x -> a x", eigvecs, anom)
-        scaled = einx.multiply("a x, a -> a x", Ut_anom, sqrt_scale)
-        pert_correction = einx.dot("e a, a x -> e x", eigvecs, scaled)
+        # Perturbations: Wₐ X′.
+        pert_correction = _apply_ctilde_func(U_y, sqrt_diff, sqrt_base, anom)
 
         particles_a = (
             einx.add("x, x -> x", x_bar, mean_correction)[None, :] + pert_correction
@@ -310,11 +345,10 @@ class EnSRF(AbstractSequentialFilter, strict=True):
         # anomalies to mean-zero anomalies, leaving the analysis mean
         # equal to ``x̄ + K v`` (see Tippett et al. 2003 §3).
         R_inv_Y = gaussx.solve_rows(obs_noise, obs_anom)
-        eigvals, eigvecs = _transform_eig(obs_anom, R_inv_Y, N_e)
-        sqrt_scale = jnp.sqrt((N_e - 1) / eigvals)
-        Ut_anom = einx.dot("e a, e x -> a x", eigvecs, anom)
-        scaled = einx.multiply("a x, a -> a x", Ut_anom, sqrt_scale)
-        pert_correction = einx.dot("e a, a x -> e x", eigvecs, scaled)
+        eigvals, U_y = _etkf_inner_spectrum(obs_anom, R_inv_Y)
+        sqrt_base = jnp.asarray(1.0, dtype=anom.dtype)
+        sqrt_diff = jnp.sqrt((N_e - 1) / ((N_e - 1) + eigvals)) - sqrt_base
+        pert_correction = _apply_ctilde_func(U_y, sqrt_diff, sqrt_base, anom)
 
         particles_a = mean_a[None, :] + pert_correction
 
@@ -430,20 +464,22 @@ class LETKF(AbstractSequentialFilter, strict=True):
             # Local ETKF in ensemble space.
             # R⁻¹_loc Y′ — broadcasted elementwise over the obs axis.
             R_inv_Y = einx.multiply("e y, y -> e y", obs_anom, inv_R_loc)
-            eigvals_loc, eigvecs_loc = _transform_eig(obs_anom, R_inv_Y, N_e)
-            inv_lambda = 1.0 / eigvals_loc
-            sqrt_scale = jnp.sqrt((N_e - 1) * inv_lambda)
-            # w̄ᵢ = U diag(1/λ) Uᵀ (Y′ R⁻¹_loc v). Sum the FIRST axis of U
-            # to apply Uᵀ — see ETKF.analysis comments.
+            eigvals_loc, U_y_loc = _etkf_inner_spectrum(obs_anom, R_inv_Y)
+
+            inv_base = jnp.asarray(1.0 / (N_e - 1), dtype=anom.dtype)
+            inv_diff = 1.0 / ((N_e - 1) + eigvals_loc) - inv_base
+            sqrt_base = jnp.asarray(1.0, dtype=anom.dtype)
+            sqrt_diff = jnp.sqrt((N_e - 1) / ((N_e - 1) + eigvals_loc)) - sqrt_base
+
+            # w̄ᵢ = T (Y′ R⁻¹_loc v); T = (1/(Nₑ−1)) I + rank-Nᵧ correction.
             Y_R_inv_v = einx.dot("e y, y -> e", R_inv_Y, innovation)
-            Ut_y = einx.dot("e a, e -> a", eigvecs_loc, Y_R_inv_v)
-            w_bar_i = einx.dot("e a, a -> e", eigvecs_loc, inv_lambda * Ut_y)
-            # Wᵢ = U diag(sqrt_scale) Uᵀ — symmetric square root.
-            W_i = einx.dot(
-                "i a, j a -> i j",
-                eigvecs_loc * sqrt_scale[None, :],
-                eigvecs_loc,
-            )
+            w_bar_i = _apply_ctilde_func(U_y_loc, inv_diff, inv_base, Y_R_inv_v)
+            # Wᵢ = I + U_y_loc diag(sqrt_diff) U_y_locᵀ — materialise the
+            # (Nₑ, Nₑ) transform so the outer ``einx`` can fuse over grid
+            # points without re-invoking per-point spectra.
+            scaled_U = einx.multiply("e a, a -> e a", U_y_loc, sqrt_diff)
+            correction = einx.dot("e a, f a -> e f", scaled_U, U_y_loc)
+            W_i = jnp.eye(N_e, dtype=anom.dtype) + correction
             return w_bar_i, W_i
 
         # vmap over state grid points → per-point (w̄ᵢ, Wᵢ).
@@ -563,20 +599,18 @@ class ETKF_Livings(AbstractSequentialFilter, strict=True):
         innovation = obs - ensemble_mean(obs_particles)
 
         R_inv_Y = gaussx.solve_rows(obs_noise, obs_anom)
-        eigvals, eigvecs = _transform_eig(obs_anom, R_inv_Y, N_e)
-        inv_lambda = 1.0 / eigvals
-        sqrt_scale = jnp.sqrt((N_e - 1) * inv_lambda)
+        eigvals, U_y = _etkf_inner_spectrum(obs_anom, R_inv_Y)
+        inv_base = jnp.asarray(1.0 / (N_e - 1), dtype=anom.dtype)
+        inv_diff = 1.0 / ((N_e - 1) + eigvals) - inv_base
+        sqrt_base = jnp.asarray(1.0, dtype=anom.dtype)
+        sqrt_diff = jnp.sqrt((N_e - 1) / ((N_e - 1) + eigvals)) - sqrt_base
 
         # ETKF weight + symmetric square root, same as the base ETKF.
         Y_R_inv_v = einx.dot("e y, y -> e", R_inv_Y, innovation)
-        Ut_y = einx.dot("e a, e -> a", eigvecs, Y_R_inv_v)
-        w_bar = einx.dot("e a, a -> e", eigvecs, inv_lambda * Ut_y)
-
+        w_bar = _apply_ctilde_func(U_y, inv_diff, inv_base, Y_R_inv_v)
         mean_correction = einx.dot("e, e x -> x", w_bar, anom)
 
-        Ut_anom = einx.dot("e a, e x -> a x", eigvecs, anom)
-        scaled = einx.multiply("a x, a -> a x", Ut_anom, sqrt_scale)
-        W_anom = einx.dot("e a, a x -> e x", eigvecs, scaled)  # (Nₑ, Nₓ)
+        W_anom = _apply_ctilde_func(U_y, sqrt_diff, sqrt_base, anom)  # (Nₑ, Nₓ)
 
         # Apply the mean-preserving rotation Θ on the *left* of W_a X′:
         # Θ leaves 𝟙 fixed, so the column-mean (== analysis mean) is
@@ -732,26 +766,23 @@ class ESTKF(AbstractSequentialFilter, strict=True):
         X_tilde = einx.dot("e r, e x -> r x", L, anom)  # (Nₑ−1, Nₓ)
         Y_tilde = einx.dot("e r, e y -> r y", L, obs_anom)  # (Nₑ−1, Nᵧ)
 
-        # Transform precision in the reduced subspace.
+        # Rank-Nᵧ spectrum of Ỹ R⁻¹ Ỹᵀ in the reduced subspace; same
+        # rank-deficiency story as ETKF, so the QR + small-eigh form
+        # keeps gradients finite.
         R_inv_Y = gaussx.solve_rows(obs_noise, Y_tilde)  # (Nₑ−1, Nᵧ)
-        A = (N_e - 1) * jnp.eye(N_e - 1, dtype=dtype) + einx.dot(
-            "r y, s y -> r s", Y_tilde, R_inv_Y
-        )
-        A = 0.5 * (A + A.T)
-        eigvals, eigvecs = jnp.linalg.eigh(A)
-        eigvals = jnp.maximum(eigvals, _EIG_FLOOR)
-        inv_lambda = 1.0 / eigvals
-        sqrt_scale = jnp.sqrt((N_e - 1) * inv_lambda)
+        eigvals, U_y = _etkf_inner_spectrum(Y_tilde, R_inv_Y)
 
-        # Reduced weights w̃ = T̃ Ỹ R⁻¹ d  ∈ ℝ^{Nₑ−1}.
+        inv_base = jnp.asarray(1.0 / (N_e - 1), dtype=dtype)
+        inv_diff = 1.0 / ((N_e - 1) + eigvals) - inv_base
+        sqrt_base = jnp.asarray(1.0, dtype=dtype)
+        sqrt_diff = jnp.sqrt((N_e - 1) / ((N_e - 1) + eigvals)) - sqrt_base
+
+        # Reduced weights w̃ = T̃ (Ỹ R⁻¹ d)  ∈ ℝ^{Nₑ−1}.
         rhs = einx.dot("r y, y -> r", R_inv_Y, innovation)
-        Ut_rhs = einx.dot("r a, r -> a", eigvecs, rhs)
-        w_tilde = einx.dot("r a, a -> r", eigvecs, inv_lambda * Ut_rhs)
+        w_tilde = _apply_ctilde_func(U_y, inv_diff, inv_base, rhs)
 
-        # Symmetric square-root applied to X̃: W̃ X̃ = U diag(s) Uᵀ X̃.
-        Ut_X = einx.dot("r a, r x -> a x", eigvecs, X_tilde)
-        scaled = einx.multiply("a x, a -> a x", Ut_X, sqrt_scale)
-        WX_tilde = einx.dot("r a, a x -> r x", eigvecs, scaled)  # (Nₑ−1, Nₓ)
+        # Symmetric square-root applied to X̃: W̃ X̃ = (I + correction) X̃.
+        WX_tilde = _apply_ctilde_func(U_y, sqrt_diff, sqrt_base, X_tilde)
 
         # Lift back to Nₑ space and assemble the analysis.
         mean_shift = einx.dot("r, r x -> x", w_tilde, X_tilde)  # (Nₓ,)

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -265,7 +265,7 @@ def test_pattern_a_learn_dynamics_params(getkey):
     H = jnp.eye(N_y, N_x)
     obs_op = _LinearObs(H=H)
     R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.05**2))
-    filter_ = flx.filters.EnSRF_Serial()
+    filter_ = flx.filters.ETKF()
 
     def loss(scale):
         dyn = _LinearDynamics(M=scale * jnp.eye(N_x))
@@ -297,7 +297,7 @@ def test_pattern_b_learn_observation_operator_params(getkey):
     times = jnp.arange(1.0, T + 1.0)
     particles = jnp.asarray(rng.standard_normal((N_e, N_x))) + truth
     R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.05**2))
-    filter_ = flx.filters.EnSRF_Serial()
+    filter_ = flx.filters.ETKF()
     dyn = _IdentityDynamics()
 
     def loss(gain):
@@ -330,7 +330,7 @@ def test_pattern_c_learn_inflation_factor(getkey):
     particles, obs, times, _, obs_op, dyn, R = _setup(
         getkey, T=T, N_e=N_e, N_x=N_x, N_y=N_y
     )
-    filter_ = flx.filters.EnSRF_Serial()
+    filter_ = flx.filters.ETKF()
 
     def loss(log_factor):
         factor = jnp.exp(log_factor)
@@ -361,7 +361,7 @@ def test_diff_assimilate_under_jit_and_grad(getkey):
     """JIT-compiled gradient of the NLL through the scan loop runs and is
     finite — required composition of jit + grad + scan."""
     particles, obs, times, _, obs_op, _dyn, R = _setup(getkey)
-    filter_ = flx.filters.EnSRF_Serial()
+    filter_ = flx.filters.ETKF()
 
     @jax.jit
     @jax.grad
@@ -380,7 +380,7 @@ def test_diff_assimilate_grad_with_checkpoint(getkey):
     """``checkpoint=True`` must round-trip through ``jax.grad`` (the whole
     reason it exists)."""
     particles, obs, times, _, obs_op, _dyn, R = _setup(getkey)
-    filter_ = flx.filters.EnSRF_Serial()
+    filter_ = flx.filters.ETKF()
 
     def loss(scale):
         dyn = _LinearDynamics(M=scale * jnp.eye(particles.shape[1]))

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -1,0 +1,400 @@
+"""Tests for the Wave 5.B differentiable assimilation loop.
+
+Two layers of coverage:
+
+1. **Algebraic correctness** — :func:`differentiable_assimilate` must
+   match the L2 :class:`filterax.ETKF` / :class:`filterax.EnSRF` Python-
+   loop assimilation step-for-step on the same inputs.
+2. **Differentiable-DA smoke tests** — gradient descent through the
+   filter must reduce the observation-space NLL when learning
+   dynamics, observation operator, or a scalar inflation parameter
+   (Patterns A / B / C from
+   ``design_docs/features/differentiable_da.md`` §6).
+
+All assertions are correctness invariants — we check that the gradient
+moves the loss in the right direction, not how close it gets to a
+specific minimiser.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+import numpy as np
+import pytest
+
+import filterax as flx
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _LinearObs(flx.AbstractObsOperator):
+    H: jnp.ndarray
+
+    def __call__(self, state):
+        return self.H @ state
+
+
+class _IdentityDynamics(flx.AbstractDynamics):
+    def __call__(self, state, t0, t1):
+        return state
+
+
+class _LinearDynamics(flx.AbstractDynamics):
+    M: jnp.ndarray
+
+    def __call__(self, state, t0, t1):
+        return self.M @ state
+
+
+def _setup(getkey, T: int = 4, N_e: int = 20, N_x: int = 3, N_y: int = 2):
+    """Linear-Gaussian assimilation problem with identity dynamics."""
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.zeros((N_y, N_x)).at[jnp.arange(N_y), jnp.arange(N_y)].set(1.0)
+    obs_op = _LinearObs(H=H)
+    dyn = _IdentityDynamics()
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.1))
+    obs = jr.normal(getkey(), (T, N_y))
+    times = jnp.arange(1.0, T + 1.0)
+    obs_list = [(obs[t], float(times[t])) for t in range(T)]
+    return particles, obs, times, obs_list, obs_op, dyn, R
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Parity with the L2 Python-loop assimilation
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_diff_assimilate_matches_l2_etkf(getkey):
+    """Scan-based loop and L2 Python-loop must produce identical history."""
+    particles, obs, times, obs_list, obs_op, dyn, R = _setup(getkey)
+    ref = flx.ETKF(dynamics=dyn, obs_op=obs_op).assimilate(particles, obs_list, R)
+    got = flx.differentiable_assimilate(
+        flx.filters.ETKF(), dyn, obs_op, particles, obs, times, R
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.forecast_history),
+        np.asarray(ref.forecast_history),
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.analysis_history),
+        np.asarray(ref.analysis_history),
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.log_likelihoods),
+        np.asarray(ref.log_likelihoods),
+        atol=1e-10,
+    )
+
+
+def test_diff_assimilate_matches_l2_ensrf(getkey):
+    """Same parity check for EnSRF."""
+    particles, obs, times, obs_list, obs_op, dyn, R = _setup(getkey)
+    ref = flx.EnSRF(dynamics=dyn, obs_op=obs_op).assimilate(particles, obs_list, R)
+    got = flx.differentiable_assimilate(
+        flx.filters.EnSRF(), dyn, obs_op, particles, obs, times, R
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.analysis_history),
+        np.asarray(ref.analysis_history),
+        atol=1e-10,
+    )
+
+
+def test_diff_assimilate_with_inflator_matches_l2(getkey):
+    """Deterministic inflator threads through the same way."""
+    particles, obs, times, obs_list, obs_op, dyn, R = _setup(getkey)
+    inflator = flx.MultiplicativeInflator(factor=1.05)
+    ref = flx.ETKF(dynamics=dyn, obs_op=obs_op, inflator=inflator).assimilate(
+        particles, obs_list, R
+    )
+    got = flx.differentiable_assimilate(
+        flx.filters.ETKF(),
+        dyn,
+        obs_op,
+        particles,
+        obs,
+        times,
+        R,
+        inflator=inflator,
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.analysis_history),
+        np.asarray(ref.analysis_history),
+        atol=1e-10,
+    )
+
+
+def test_diff_assimilate_letkf_with_coords(getkey):
+    """LETKF needs ``state_coords`` / ``obs_coords`` — they thread through
+    ``analysis_extra`` and the scan loop matches the L2 LETKF."""
+    N_e, N_x, N_y, T = 20, 4, 2, 3
+    particles = jr.normal(getkey(), (N_e, N_x))
+    state_coords = jnp.arange(N_x, dtype=jnp.float64)[:, None]
+    obs_coords = jnp.asarray([[0.5], [2.5]])
+    H = jnp.zeros((N_y, N_x)).at[jnp.arange(N_y), jnp.asarray([0, 2])].set(1.0)
+    obs_op = _LinearObs(H=H)
+    dyn = _IdentityDynamics()
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.3))
+    obs = jr.normal(getkey(), (T, N_y))
+    times = jnp.arange(1.0, T + 1.0)
+    obs_list = [(obs[t], float(times[t])) for t in range(T)]
+
+    ref = flx.LETKF(dynamics=dyn, obs_op=obs_op, radius=1.5).assimilate(
+        particles, obs_list, R, state_coords=state_coords, obs_coords=obs_coords
+    )
+    got = flx.differentiable_assimilate(
+        flx.filters.LETKF(radius=1.5),
+        dyn,
+        obs_op,
+        particles,
+        obs,
+        times,
+        R,
+        state_coords=state_coords,
+        obs_coords=obs_coords,
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.analysis_history),
+        np.asarray(ref.analysis_history),
+        atol=1e-10,
+    )
+
+
+def test_diff_assimilate_checkpoint_is_value_equivalent(getkey):
+    """``checkpoint=True`` is a memory/compute trade-off, not a numerical
+    change — the output values must be identical."""
+    particles, obs, times, _, obs_op, dyn, R = _setup(getkey)
+    eager = flx.differentiable_assimilate(
+        flx.filters.ETKF(), dyn, obs_op, particles, obs, times, R, checkpoint=False
+    )
+    ckpt = flx.differentiable_assimilate(
+        flx.filters.ETKF(), dyn, obs_op, particles, obs, times, R, checkpoint=True
+    )
+    np.testing.assert_allclose(
+        np.asarray(ckpt.analysis_history),
+        np.asarray(eager.analysis_history),
+        atol=1e-12,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_rejects_stochastic_enkf(getkey):
+    particles, obs, times, _, obs_op, dyn, R = _setup(getkey)
+    with pytest.raises(ValueError, match="StochasticEnKF"):
+        flx.differentiable_assimilate(
+            flx.filters.StochasticEnKF(0), dyn, obs_op, particles, obs, times, R
+        )
+
+
+def test_rejects_etkf_livings(getkey):
+    particles, obs, times, _, obs_op, dyn, R = _setup(getkey)
+    with pytest.raises(ValueError, match="ETKF_Livings"):
+        flx.differentiable_assimilate(
+            flx.filters.ETKF_Livings(0), dyn, obs_op, particles, obs, times, R
+        )
+
+
+def test_rejects_additive_inflator(getkey):
+    particles, obs, times, _, obs_op, dyn, R = _setup(getkey)
+    inflator = flx.AdditiveInflator(
+        noise_cov=lx.DiagonalLinearOperator(jnp.full(particles.shape[1], 0.01)),
+        base_key=jr.PRNGKey(0),
+    )
+    with pytest.raises(ValueError, match="AdditiveInflator"):
+        flx.differentiable_assimilate(
+            flx.filters.ETKF(),
+            dyn,
+            obs_op,
+            particles,
+            obs,
+            times,
+            R,
+            inflator=inflator,
+        )
+
+
+def test_rejects_mismatched_obs_and_times(getkey):
+    particles, obs, times, _, obs_op, dyn, R = _setup(getkey, T=4)
+    with pytest.raises(ValueError, match="same leading axis"):
+        flx.differentiable_assimilate(
+            flx.filters.ETKF(), dyn, obs_op, particles, obs, times[:3], R
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Differentiable-DA training patterns (smoke)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _nll(result):
+    """Negative log-likelihood, summed over the assimilation window."""
+    return -jnp.sum(result.log_likelihoods)
+
+
+def test_pattern_a_learn_dynamics_params(getkey):
+    """Pattern A: backprop the observation-space NLL through the filter
+    moves a learnable scalar dynamics parameter toward the truth.
+
+    ``true_M = 0.95 * I``; the loss-gradient at ``M = 1.0 * I`` should
+    have the right sign to push the parameter *down* (toward 0.95).
+    """
+    N_e, N_x, N_y, T = 20, 2, 2, 6
+    rng = np.random.default_rng(0)
+    truth_traj = np.zeros((T, N_x))
+    state = np.array([1.0, -0.5])
+    H_np = np.eye(N_y, N_x)
+    for t in range(T):
+        state = 0.95 * state
+        truth_traj[t] = state
+    obs = jnp.asarray(truth_traj @ H_np.T + 0.05 * rng.standard_normal((T, N_y)))
+    times = jnp.arange(1.0, T + 1.0)
+    particles = jnp.asarray(rng.standard_normal((N_e, N_x))) + jnp.array([1.0, -0.5])
+
+    H = jnp.eye(N_y, N_x)
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.05**2))
+    filter_ = flx.filters.EnSRF_Serial()
+
+    def loss(scale):
+        dyn = _LinearDynamics(M=scale * jnp.eye(N_x))
+        result = flx.differentiable_assimilate(
+            filter_, dyn, obs_op, particles, obs, times, R
+        )
+        return _nll(result)
+
+    grad_at_one = jax.grad(loss)(1.0)
+    # NLL increases when M is too large (true M = 0.95); gradient at
+    # ``scale = 1.0`` should be positive so a descent step *decreases* scale.
+    assert float(grad_at_one) > 0
+    # One descent step lowers the loss.
+    step = 0.01
+    loss_before = float(loss(1.0))
+    loss_after = float(loss(1.0 - step * jnp.sign(grad_at_one)))
+    assert loss_after < loss_before
+
+
+def test_pattern_b_learn_observation_operator_params(getkey):
+    """Pattern B: learn the observation operator (a scalar gain on the
+    first state component) end-to-end through the filter."""
+    N_e, N_x, N_y, T = 20, 2, 1, 4
+    rng = np.random.default_rng(1)
+    # True observation: y = 2.0 * x[0]; we'll start at gain = 1.0.
+    truth = np.array([1.5, -0.7])
+    truth_traj = np.tile(truth, (T, 1))
+    obs = jnp.asarray(2.0 * truth_traj[:, :1] + 0.05 * rng.standard_normal((T, N_y)))
+    times = jnp.arange(1.0, T + 1.0)
+    particles = jnp.asarray(rng.standard_normal((N_e, N_x))) + truth
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.05**2))
+    filter_ = flx.filters.EnSRF_Serial()
+    dyn = _IdentityDynamics()
+
+    def loss(gain):
+        H = jnp.asarray([[gain, 0.0]])
+        obs_op = _LinearObs(H=H)
+        result = flx.differentiable_assimilate(
+            filter_, dyn, obs_op, particles, obs, times, R
+        )
+        return _nll(result)
+
+    grad_at_one = jax.grad(loss)(1.0)
+    # True gain is 2.0; loss should be lower for larger gain, so the
+    # gradient at gain = 1.0 must be negative.
+    assert float(grad_at_one) < 0
+    step = 0.05
+    loss_before = float(loss(1.0))
+    loss_after = float(loss(1.0 - step * grad_at_one / jnp.abs(grad_at_one)))
+    assert loss_after < loss_before
+
+
+def test_pattern_c_learn_inflation_factor(getkey):
+    """Pattern C: optimise a learnable multiplicative inflation factor.
+
+    The differentiable path uses the low-level ``inflate_multiplicative``
+    primitive (which is gradient-friendly in ``factor``) rather than
+    ``MultiplicativeInflator``'s static field. Loss should drop when we
+    step in the negative-gradient direction.
+    """
+    N_e, N_x, N_y, T = 20, 3, 2, 4
+    particles, obs, times, _, obs_op, dyn, R = _setup(
+        getkey, T=T, N_e=N_e, N_x=N_x, N_y=N_y
+    )
+    filter_ = flx.filters.EnSRF_Serial()
+
+    def loss(log_factor):
+        factor = jnp.exp(log_factor)
+
+        # Hand-rolled differentiable step using the package's primitives.
+        def step(carry, inputs):
+            ens, t_prev = carry
+            obs_t, t_now = inputs
+            forecast = jax.vmap(lambda x: dyn(x, t_prev, t_now))(ens)
+            result = filter_.analysis(forecast, obs_t, obs_op, R)
+            analysed = flx.inflate_multiplicative(result.particles, factor)
+            return (analysed, t_now), result.log_likelihood
+
+        _, logps = jax.lax.scan(step, (particles, jnp.asarray(0.0)), (obs, times))
+        return -jnp.sum(logps)
+
+    log_factor_0 = jnp.log(1.2)
+    grad = jax.grad(loss)(log_factor_0)
+    assert jnp.isfinite(grad)
+    assert grad != 0.0
+    step = 0.05
+    loss_before = float(loss(log_factor_0))
+    loss_after = float(loss(log_factor_0 - step * jnp.sign(grad)))
+    assert loss_after < loss_before
+
+
+def test_diff_assimilate_under_jit_and_grad(getkey):
+    """JIT-compiled gradient of the NLL through the scan loop runs and is
+    finite — required composition of jit + grad + scan."""
+    particles, obs, times, _, obs_op, _dyn, R = _setup(getkey)
+    filter_ = flx.filters.EnSRF_Serial()
+
+    @jax.jit
+    @jax.grad
+    def grad_loss(scale):
+        dyn = _LinearDynamics(M=scale * jnp.eye(particles.shape[1]))
+        result = flx.differentiable_assimilate(
+            filter_, dyn, obs_op, particles, obs, times, R
+        )
+        return _nll(result)
+
+    g = grad_loss(1.0)
+    assert jnp.isfinite(g)
+
+
+def test_diff_assimilate_grad_with_checkpoint(getkey):
+    """``checkpoint=True`` must round-trip through ``jax.grad`` (the whole
+    reason it exists)."""
+    particles, obs, times, _, obs_op, _dyn, R = _setup(getkey)
+    filter_ = flx.filters.EnSRF_Serial()
+
+    def loss(scale):
+        dyn = _LinearDynamics(M=scale * jnp.eye(particles.shape[1]))
+        result = flx.differentiable_assimilate(
+            filter_,
+            dyn,
+            obs_op,
+            particles,
+            obs,
+            times,
+            R,
+            checkpoint=True,
+        )
+        return _nll(result)
+
+    g = jax.grad(loss)(1.0)
+    assert jnp.isfinite(g)

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -94,22 +94,42 @@ def test_diff_assimilate_matches_l2_etkf(getkey):
     )
 
 
+def _assert_full_result_match(got, ref, atol):
+    """Compare every field of an ``AssimilationResult`` — forecasts,
+    analyses, terminal particles, and log-likelihoods."""
+    np.testing.assert_allclose(
+        np.asarray(got.forecast_history),
+        np.asarray(ref.forecast_history),
+        atol=atol,
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.analysis_history),
+        np.asarray(ref.analysis_history),
+        atol=atol,
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.particles), np.asarray(ref.particles), atol=atol
+    )
+    np.testing.assert_allclose(
+        np.asarray(got.log_likelihoods),
+        np.asarray(ref.log_likelihoods),
+        atol=atol,
+    )
+
+
 def test_diff_assimilate_matches_l2_ensrf(getkey):
-    """Same parity check for EnSRF."""
+    """Same parity check for EnSRF — full step-for-step equivalence."""
     particles, obs, times, obs_list, obs_op, dyn, R = _setup(getkey)
     ref = flx.EnSRF(dynamics=dyn, obs_op=obs_op).assimilate(particles, obs_list, R)
     got = flx.differentiable_assimilate(
         flx.filters.EnSRF(), dyn, obs_op, particles, obs, times, R
     )
-    np.testing.assert_allclose(
-        np.asarray(got.analysis_history),
-        np.asarray(ref.analysis_history),
-        atol=1e-10,
-    )
+    _assert_full_result_match(got, ref, atol=1e-10)
 
 
 def test_diff_assimilate_with_inflator_matches_l2(getkey):
-    """Deterministic inflator threads through the same way."""
+    """Deterministic inflator threads through the same way — full
+    step-for-step equivalence across every result field."""
     particles, obs, times, obs_list, obs_op, dyn, R = _setup(getkey)
     inflator = flx.MultiplicativeInflator(factor=1.05)
     ref = flx.ETKF(dynamics=dyn, obs_op=obs_op, inflator=inflator).assimilate(
@@ -125,16 +145,13 @@ def test_diff_assimilate_with_inflator_matches_l2(getkey):
         R,
         inflator=inflator,
     )
-    np.testing.assert_allclose(
-        np.asarray(got.analysis_history),
-        np.asarray(ref.analysis_history),
-        atol=1e-10,
-    )
+    _assert_full_result_match(got, ref, atol=1e-10)
 
 
 def test_diff_assimilate_letkf_with_coords(getkey):
     """LETKF needs ``state_coords`` / ``obs_coords`` — they thread through
-    ``analysis_extra`` and the scan loop matches the L2 LETKF."""
+    ``analysis_extra`` and the scan loop matches the L2 LETKF across
+    every result field."""
     N_e, N_x, N_y, T = 20, 4, 2, 3
     particles = jr.normal(getkey(), (N_e, N_x))
     state_coords = jnp.arange(N_x, dtype=jnp.float64)[:, None]
@@ -161,16 +178,12 @@ def test_diff_assimilate_letkf_with_coords(getkey):
         state_coords=state_coords,
         obs_coords=obs_coords,
     )
-    np.testing.assert_allclose(
-        np.asarray(got.analysis_history),
-        np.asarray(ref.analysis_history),
-        atol=1e-10,
-    )
+    _assert_full_result_match(got, ref, atol=1e-10)
 
 
 def test_diff_assimilate_checkpoint_is_value_equivalent(getkey):
     """``checkpoint=True`` is a memory/compute trade-off, not a numerical
-    change — the output values must be identical."""
+    change — every result field must match the eager run exactly."""
     particles, obs, times, _, obs_op, dyn, R = _setup(getkey)
     eager = flx.differentiable_assimilate(
         flx.filters.ETKF(), dyn, obs_op, particles, obs, times, R, checkpoint=False
@@ -178,11 +191,7 @@ def test_diff_assimilate_checkpoint_is_value_equivalent(getkey):
     ckpt = flx.differentiable_assimilate(
         flx.filters.ETKF(), dyn, obs_op, particles, obs, times, R, checkpoint=True
     )
-    np.testing.assert_allclose(
-        np.asarray(ckpt.analysis_history),
-        np.asarray(eager.analysis_history),
-        atol=1e-12,
-    )
+    _assert_full_result_match(ckpt, eager, atol=1e-12)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -231,6 +240,21 @@ def test_rejects_mismatched_obs_and_times(getkey):
         flx.differentiable_assimilate(
             flx.filters.ETKF(), dyn, obs_op, particles, obs, times[:3], R
         )
+
+
+def test_diff_assimilate_handles_mixed_time_dtypes(getkey):
+    """Regression: ``lax.scan`` requires the carry's input and output
+    dtypes to match exactly. The scan loop unifies ``t0`` and
+    ``obs_times`` to a common dtype up front so float32 ensembles paired
+    with int / float64 timestamps trace cleanly."""
+    particles, obs, _times, _, obs_op, dyn, R = _setup(getkey)
+    # Integer timestamps + scalar t0 — previously crashed at trace time.
+    int_times = jnp.arange(1, obs.shape[0] + 1, dtype=jnp.int32)
+    result = flx.differentiable_assimilate(
+        flx.filters.ETKF(), dyn, obs_op, particles, obs, int_times, R, t0=0
+    )
+    assert result.analysis_history.shape == (obs.shape[0], *particles.shape)
+    assert bool(jnp.all(jnp.isfinite(result.analysis_history)))
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_jax_transforms.py
+++ b/tests/test_jax_transforms.py
@@ -68,3 +68,100 @@ def test_kalman_gain_differentiable_wrt_particles(getkey):
     g = jax.grad(scalar, argnums=0)(p, o)
     assert g.shape == p.shape
     assert jnp.isfinite(g).all()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Gradient stability of L1 sequential filters (regression for #82).
+#
+# The old ``_transform_eig`` decomposed an (N_e, N_e) matrix with
+# ``N_e − N_y`` structurally-repeated eigenvalues; JAX's ``eigh`` JVP
+# returns ``NaN`` for repeated eigenvalues, so reverse-mode gradients
+# through ETKF / EnSRF / ESTKF / LETKF / ETKF_Livings all NaN-out for
+# ``N_e >> N_y``. The QR-based rank-``N_y`` reformulation removes the
+# degeneracy entirely. These tests run at ``N_e = N_y + 20`` so the
+# old code reliably NaN'd and the new code stays finite.
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _LinObs(flx.AbstractObsOperator):
+    H: jnp.ndarray
+
+    def __call__(self, state):
+        return self.H @ state
+
+
+def _grad_through_analysis(filter_, particles, obs, obs_op, R, **kwargs):
+    def loss(scale):
+        forecast = particles @ (scale * jnp.eye(particles.shape[1])).T
+        result = filter_.analysis(forecast, obs, obs_op, R, **kwargs)
+        return jnp.sum(result.particles**2)
+
+    return jax.grad(loss)(1.0)
+
+
+def test_etkf_grad_finite_at_large_ensemble(getkey):
+    N_e, N_x, N_y = 30, 4, 3
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.zeros((N_y, N_x)).at[jnp.arange(N_y), jnp.arange(N_y)].set(1.0)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.1))
+    g = _grad_through_analysis(
+        flx.filters.ETKF(), particles, jnp.zeros(N_y), _LinObs(H=H), R
+    )
+    assert jnp.isfinite(g)
+    assert g != 0.0
+
+
+def test_ensrf_grad_finite_at_large_ensemble(getkey):
+    N_e, N_x, N_y = 30, 4, 3
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.zeros((N_y, N_x)).at[jnp.arange(N_y), jnp.arange(N_y)].set(1.0)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.1))
+    g = _grad_through_analysis(
+        flx.filters.EnSRF(), particles, jnp.zeros(N_y), _LinObs(H=H), R
+    )
+    assert jnp.isfinite(g)
+    assert g != 0.0
+
+
+def test_estkf_grad_finite_at_large_ensemble(getkey):
+    N_e, N_x, N_y = 30, 4, 3
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.zeros((N_y, N_x)).at[jnp.arange(N_y), jnp.arange(N_y)].set(1.0)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.1))
+    g = _grad_through_analysis(
+        flx.filters.ESTKF(), particles, jnp.zeros(N_y), _LinObs(H=H), R
+    )
+    assert jnp.isfinite(g)
+    assert g != 0.0
+
+
+def test_letkf_grad_finite_at_large_ensemble(getkey):
+    N_e, N_x, N_y = 30, 6, 3
+    particles = jr.normal(getkey(), (N_e, N_x))
+    state_coords = jnp.arange(N_x, dtype=jnp.float64)[:, None]
+    obs_coords = jnp.asarray([[0.5], [2.5], [4.5]])
+    H = jnp.zeros((N_y, N_x)).at[jnp.arange(N_y), jnp.asarray([0, 2, 4])].set(1.0)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.3))
+    g = _grad_through_analysis(
+        flx.filters.LETKF(radius=1.5),
+        particles,
+        jnp.zeros(N_y),
+        _LinObs(H=H),
+        R,
+        state_coords=state_coords,
+        obs_coords=obs_coords,
+    )
+    assert jnp.isfinite(g)
+    assert g != 0.0
+
+
+def test_etkf_livings_grad_finite_at_large_ensemble(getkey):
+    N_e, N_x, N_y = 30, 4, 3
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.zeros((N_y, N_x)).at[jnp.arange(N_y), jnp.arange(N_y)].set(1.0)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.1))
+    g = _grad_through_analysis(
+        flx.filters.ETKF_Livings(0), particles, jnp.zeros(N_y), _LinObs(H=H), R
+    )
+    assert jnp.isfinite(g)
+    assert g != 0.0


### PR DESCRIPTION
Closes #59 and #82. Wave 5.B implementation.

Two commits in this PR — they're tightly coupled (the second is what makes the first actually usable with the canonical filters from the design doc):

1. **`feat(differentiable)`** — `filterax.differentiable_assimilate`, a `jax.lax.scan`-based equivalent of `model.assimilate(...)` with optional `jax.checkpoint`.
2. **`fix(filters)`** — replace the structurally-degenerate `(N_e, N_e)` `eigh` in ETKF / EnSRF / LETKF / ETKF_Livings / ESTKF with a rank-`N_y` QR + small-`eigh` reformulation so gradients stay finite at any `N_e`.

## 1 — Differentiable assimilation (closes #59)

`filterax.differentiable_assimilate` is the scan + vmap + remat idiom from `design_docs/features/differentiable_da.md`:

- `jax.lax.scan` over a stacked `(T, N_y)` observation history — fixed-shape loop body, single fused XLA `While`, constant compile time vs `T`.
- Optional `jax.checkpoint` wrap of the step for `O(√T)` backward-pass memory over long histories.
- Refuses `StochasticEnKF`, `ETKF_Livings`, and `AdditiveInflator` (per-step PRNG draws break smooth gradients) with clear errors pointing at the design doc.

```python
result = filterax.differentiable_assimilate(
    filter_,                  # deterministic L1 filter
    dynamics, obs_op,
    init_ensemble,            # (N_e, N_x)
    observations,             # (T, N_y) stacked
    obs_times,                # (T,)     stacked
    obs_noise,
    inflator=...,             # optional, deterministic
    checkpoint=False,         # opt-in O(sqrt(T)) memory under grad
    **analysis_extra,         # forwarded to filter_.analysis (LETKF coords, etc.)
)
loss = -jnp.sum(result.log_likelihoods)
```

## 2 — Rank-`N_y` filter spectrum (closes #82)

The old `_transform_eig` decomposed

```
C̃ = (N_e − 1) I + Y′ R⁻¹ Y′ᵀ
```

via `jnp.linalg.eigh` on the full `(N_e, N_e)` matrix. `C̃` has `N_e − N_y` *repeated* eigenvalues `(N_e − 1)`; JAX's `eigh` JVP returns `NaN` for repeated eigenvalues, so reverse-mode gradients through ETKF / EnSRF / ESTKF / LETKF / ETKF_Livings NaN-out for `N_e ≫ N_y` — exactly the differentiable-DA setting.

New construction:

```
Y′ = Q R_qr                   # thin QR; Q ∈ ℝ^{K × N_y}
M_y = R_qr R⁻¹ R_qrᵀ           # (N_y, N_y), symmetric PSD
M_y = V_M diag(λ_i) V_Mᵀ       # eigh on the SMALL matrix
U_y = Q V_M

g(C̃) v = g(N_e − 1) · v + U_y diag(g((N_e − 1) + λ_i) − g(N_e − 1)) U_yᵀ v
```

The structurally-degenerate null subspace is never made explicit — downstream functions evaluate only at the `N_y` non-trivial eigenvalues. Algebraically identical to the old code; the existing linear-Gaussian baselines all still pass at `atol = 1e-9 / 1e-8`.

Two helpers (`_etkf_inner_spectrum`, `_apply_ctilde_func`) cover all five filters. ESTKF uses the same machinery in its `(N_e − 1)`-dim reduced subspace.

## Test plan

- [x] **5 new gradient-stability regression tests** in `test_jax_transforms.py` — one per filter (ETKF / EnSRF / ESTKF / LETKF / ETKF_Livings) at `N_e = 30, N_y = 3`, well past the `N_e > N_y + 10` threshold where the old code NaN'd. All return finite, non-zero gradients.
- [x] **Existing linear-Gaussian baselines unchanged** — same atol (1e-9 / 1e-8), confirming the new code is algebraically identical, not an approximation.
- [x] **Wave 5.B smoke tests** (Patterns A / B / C from the design doc) now run with **ETKF** instead of the `EnSRF_Serial` workaround.
- [x] 14 new tests for `differentiable_assimilate`: parity with L2 `ETKF` / `EnSRF` / `LETKF` (atol 1e-10), parity with a `MultiplicativeInflator`, `checkpoint=True` value-equivalence, validation errors, JIT + grad composition.
- [x] Full suite: **192 passed in 140s** (up from 173 → no regressions, +19 tests).

## Follow-ups
None of the Wave 5 implementation tickets remaining. Next up: #60 (`integrations(minimal)` — optax / somax / gaussx seams) or jump to Wave 6 examples.

https://claude.ai/code/session_01PPKxuHPad9k8wf3XsnKxvt