### PR TITLE
feat(differentiable): add ROAD-EnKF local-gradient training

### DIFF
--- a/docs/design_docs/features/differentiable_da.md
+++ b/docs/design_docs/features/differentiable_da.md
@@ -368,6 +368,20 @@ This reduces the backward pass from $O(T)$ sequential steps to $O(1)$
 per time step (parallelizable), at the cost of ignoring cross-time
 gradient interactions.
 
+**Shipped** as `filterax.differentiable.road_enkf_loss_and_grad`
+(with the `road_enkf_grad_step` optax-update convenience wrapper);
+the code below is the algorithm sketch the implementation realises.
+
+```python
+from filterax.differentiable import road_enkf_loss_and_grad
+
+loss, dynamics_grad = road_enkf_loss_and_grad(
+    dynamics, init_ensemble, observations, obs_times, R, obs_op,
+)
+```
+
+Internally:
+
 ```python
 def road_enkf_gradient(dynamics, y_obs, x0_ens, H, R):
     """ROAD-EnKF: local gradients, no full unrolling."""

--- a/src/filterax/__init__.py
+++ b/src/filterax/__init__.py
@@ -1,6 +1,7 @@
 """filterax — differentiable ensemble Kalman filters and processes for JAX."""
 
 from filterax import (
+    differentiable as differentiable,
     filters as filters,
     optax as optax,
     processes as processes,

--- a/src/filterax/_src/road.py
+++ b/src/filterax/_src/road.py
@@ -113,8 +113,6 @@ def road_enkf_loss_and_grad(
             f"got {observations.shape[0]} and {obs_times.shape[0]}."
         )
 
-    T = int(observations.shape[0])
-
     def local_step(
         dyn: AbstractDynamics,
         ensemble: Float[Array, "N_e N_x"],
@@ -155,29 +153,37 @@ def road_enkf_loss_and_grad(
     # integer/bool array leaves (indices, masks, PRNG-key metadata)
     # rather than seeding zero "gradients" optax would then try to
     # apply to them.
-    total_grad: PyTree = jax.tree.map(
+    total_grad_seed: PyTree = jax.tree.map(
         lambda leaf: jnp.zeros_like(leaf) if eqx.is_inexact_array(leaf) else None,
         eqx.filter(dynamics, eqx.is_inexact_array),
     )
-    total_loss = jnp.asarray(0.0, dtype=init_ensemble.dtype)
-    ensemble = init_ensemble
-    t_prev = t0_arr
+    loss_seed = jnp.asarray(0.0, dtype=init_ensemble.dtype)
 
-    # Python loop — each iteration carries its own short backward-pass
-    # tape; ``stop_gradient`` between iterations is what keeps memory
-    # at ``O(Nₑ · Nₓ)`` regardless of ``T``.
-    for t in range(T):
-        t_now = obs_times[t]
+    # ``jax.lax.scan`` over the observation history. Each iteration runs
+    # ``filter_value_and_grad`` on the per-step local loss; the resulting
+    # gradient accumulates into a carry leaf of the same dynamics-shaped
+    # PyTree. ``stop_gradient`` on the analysis particles between
+    # iterations stops any reverse-mode tape from spanning steps — so the
+    # backward-pass memory stays ``O(Nₑ · Nₓ)`` and, equally important,
+    # the *forward* JIT trace stays ``O(1)`` in ``T`` (the loop body is
+    # traced once and ``lax.scan`` carries it).
+    def scan_step(carry, inputs):
+        ensemble, total_loss, total_grad, t_prev = carry
+        obs_t, t_now = inputs
         (loss_t, analysis_particles), grad_t = grad_step(
-            dynamics, ensemble, t_prev, t_now, observations[t]
+            dynamics, ensemble, t_prev, t_now, obs_t
         )
-        total_loss = total_loss + loss_t
-        total_grad = jax.tree.map(
-            lambda acc, g: acc if g is None else acc + g, total_grad, grad_t
+        new_total_loss = total_loss + loss_t
+        new_total_grad = jax.tree.map(
+            lambda acc, g: acc + g, total_grad, grad_t
         )
-        ensemble = jax.lax.stop_gradient(analysis_particles)
-        t_prev = t_now
+        new_ensemble = jax.lax.stop_gradient(analysis_particles)
+        return (new_ensemble, new_total_loss, new_total_grad, t_now), None
 
+    init_carry = (init_ensemble, loss_seed, total_grad_seed, t0_arr)
+    (_, total_loss, total_grad, _), _ = jax.lax.scan(
+        scan_step, init_carry, (observations, obs_times)
+    )
     return total_loss, total_grad
 
 
@@ -207,7 +213,18 @@ def road_enkf_grad_step(
         dynamics: Forward model to update.
         optimizer: Any ``optax.GradientTransformation``
             (``optax.adam(1e-3)``, ``optax.chain(...)``, …).
-        opt_state: Optimizer state produced by ``optimizer.init(dynamics)``.
+        opt_state: Optimizer state. Initialise with the *inexact*
+            (gradient-eligible) leaves only — matches what the gradient
+            update will write to::
+
+                opt_state = optimizer.init(
+                    eqx.filter(dynamics, eqx.is_inexact_array)
+                )
+
+            Filtering on ``eqx.is_array`` instead would let optax try
+            to write float updates onto integer / boolean metadata
+            (indices, masks, …) and either fail or silently corrupt
+            those fields.
         init_ensemble: Prior ensemble ``(Nₑ, Nₓ)``.
         observations: Stacked observation history ``(T, Nᵧ)``.
         obs_times: Stacked timestamps ``(T,)``.

--- a/src/filterax/_src/road.py
+++ b/src/filterax/_src/road.py
@@ -148,12 +148,16 @@ def road_enkf_loss_and_grad(
     t0_arr = t0_arr.astype(time_dtype)
     obs_times = obs_times.astype(time_dtype)
 
-    # Seed the gradient accumulator with the right pytree shape (zeros over
-    # array leaves of ``dynamics``; non-array leaves stay as-is and are
-    # ignored by ``filter_value_and_grad``).
+    # Seed the gradient accumulator with the right pytree shape — zeros
+    # over *inexact* array leaves (float / complex) of ``dynamics``.
+    # ``eqx.filter_value_and_grad`` only ever produces gradients for
+    # inexact leaves, so we use ``eqx.is_inexact_array`` here to skip
+    # integer/bool array leaves (indices, masks, PRNG-key metadata)
+    # rather than seeding zero "gradients" optax would then try to
+    # apply to them.
     total_grad: PyTree = jax.tree.map(
-        lambda leaf: jnp.zeros_like(leaf) if eqx.is_array(leaf) else None,
-        eqx.filter(dynamics, eqx.is_array),
+        lambda leaf: jnp.zeros_like(leaf) if eqx.is_inexact_array(leaf) else None,
+        eqx.filter(dynamics, eqx.is_inexact_array),
     )
     total_loss = jnp.asarray(0.0, dtype=init_ensemble.dtype)
     ensemble = init_ensemble
@@ -231,10 +235,14 @@ def road_enkf_grad_step(
         t0=t0,
         **analysis_extra,
     )
-    # Pass only the array leaves of ``dynamics`` to optax (matches what
-    # ``optimizer.init(eqx.filter(dynamics, eqx.is_array))`` consumes; otherwise
-    # optax's static type for ``params`` rejects the bare ``eqx.Module``).
-    params = eqx.filter(dynamics, eqx.is_array)
+    # Pass only the *inexact* (gradient-eligible) array leaves of
+    # ``dynamics`` to optax — matches the ``eqx.is_inexact_array`` filter
+    # used to seed the gradient accumulator in
+    # ``road_enkf_loss_and_grad`` and the convention callers should use
+    # when constructing ``opt_state = optimizer.init(eqx.filter(dynamics,
+    # eqx.is_inexact_array))``. Filtering on ``eqx.is_array`` instead
+    # would let optax try to write updates onto integer / bool leaves.
+    params = eqx.filter(dynamics, eqx.is_inexact_array)
     updates, new_opt_state = optimizer.update(grads, opt_state, params)
     new_dynamics = eqx.apply_updates(dynamics, updates)
     return new_dynamics, new_opt_state, loss

--- a/src/filterax/_src/road.py
+++ b/src/filterax/_src/road.py
@@ -174,9 +174,7 @@ def road_enkf_loss_and_grad(
             dynamics, ensemble, t_prev, t_now, obs_t
         )
         new_total_loss = total_loss + loss_t
-        new_total_grad = jax.tree.map(
-            lambda acc, g: acc + g, total_grad, grad_t
-        )
+        new_total_grad = jax.tree.map(lambda acc, g: acc + g, total_grad, grad_t)
         new_ensemble = jax.lax.stop_gradient(analysis_particles)
         return (new_ensemble, new_total_loss, new_total_grad, t_now), None
 

--- a/src/filterax/_src/road.py
+++ b/src/filterax/_src/road.py
@@ -1,0 +1,240 @@
+"""ROAD-EnKF — reduced-order autodifferentiable EnKF (Wave 5.B+).
+
+Memory-efficient gradient strategy for training through the filter on
+long observation horizons. Where :func:`differentiable_assimilate` keeps
+the full reverse-mode autodiff tape over ``T`` filter cycles (memory
+``O(T · Nₑ · Nₓ)``, or ``O(√T · Nₑ · Nₓ)`` with ``jax.checkpoint``),
+ROAD-EnKF takes the **local-gradient** approach:
+
+1. At step ``t``, compute the per-step loss ``L_t = -log p(y_t | X^f_t)``
+   *with* gradient enabled, getting a local gradient
+   ``∇_θ L_t``.
+2. Sum the local gradients across all steps:
+   ``∇_θ L ≈ Σ_t ∇_θ L_t``.
+3. Advance the ensemble between steps with :func:`jax.lax.stop_gradient`
+   so no autodiff tape spans more than one filter cycle.
+
+Backward-pass memory stays ``O(Nₑ · Nₓ)`` regardless of ``T``. The
+trade-off is that *cross-time* gradient terms are dropped — the local
+gradient ``∇_θ L_t`` reflects how ``θ`` shapes the forecast / analysis
+at step ``t``, but does **not** include the chain
+``∂L_t / ∂X^a_{t-1} · ∂X^a_{t-1} / ∂θ``. In practice this is the
+accepted ROAD-EnKF trade-off (Chen et al. 2023) — for long horizons the
+cross-time terms decay through the filter's stability and the
+gradient-bias-vs-memory trade is heavily favoured.
+
+References
+----------
+* Chen, Y., Huang, D. Z. & Stuart, A. M. (2023). *ROAD-EnKF:
+  Reduced-Order Autodiff Ensemble Kalman Filters.*
+  https://github.com/ymchen0/ROAD-EnKF
+* :mod:`filterax._src.differentiable` — companion full-backprop loop.
+* ``design_docs/features/differentiable_da.md`` §6.D — algorithm
+  derivation in the project's vocabulary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import optax
+from jaxtyping import Array, Float, PyTree
+
+from filterax._src._protocols import (
+    AbstractDynamics,
+    AbstractInflator,
+    AbstractObsOperator,
+    AbstractSequentialFilter,
+)
+from filterax._src.differentiable import _forecast, _reject_stochastic_components
+
+
+def road_enkf_loss_and_grad(
+    dynamics: AbstractDynamics,
+    init_ensemble: Float[Array, "N_e N_x"],
+    observations: Float[Array, "T N_y"],
+    obs_times: Float[Array, " T"],
+    obs_noise: lx.AbstractLinearOperator,
+    obs_op: AbstractObsOperator,
+    *,
+    filter_: AbstractSequentialFilter | None = None,
+    inflator: AbstractInflator | None = None,
+    t0: float | Float[Array, ""] = 0.0,
+    **analysis_extra: Any,
+) -> tuple[Float[Array, ""], PyTree]:
+    r"""Local-gradient NLL loss and dynamics gradient on a filter window.
+
+    Per-step :func:`equinox.filter_value_and_grad` over the forecast +
+    analysis cycle, with :func:`jax.lax.stop_gradient` between cycles.
+    Backward-pass memory is ``O(Nₑ · Nₓ)`` independent of ``T`` (cf.
+    :func:`differentiable_assimilate` whose tape grows linearly in
+    ``T``).
+
+    Args:
+        dynamics: Forward model. Trainable: every array leaf of this
+            ``AbstractDynamics`` PyTree contributes a gradient.
+        init_ensemble: Prior ensemble ``(Nₑ, Nₓ)``.
+        observations: Stacked observation history ``(T, Nᵧ)``.
+        obs_times: Stacked timestamps ``(T,)`` — the forecast for window
+            ``t`` propagates from ``obs_times[t-1]`` (or ``t0`` when
+            ``t == 0``) to ``obs_times[t]``.
+        obs_noise: Observation error covariance ``R``.
+        obs_op: Observation operator ``H``.
+        filter_: Deterministic L1 filter (``ETKF`` by default).
+            Stochastic filters (``StochasticEnKF``, ``ETKF_Livings``)
+            and the stochastic ``AdditiveInflator`` are rejected at
+            call time — their PRNG draws break smooth gradients.
+        inflator: Optional deterministic inflator
+            (``MultiplicativeInflator`` / ``RTPS`` / ``RTPP``).
+        t0: Starting time used for the first forecast window.
+        **analysis_extra: Forwarded to ``filter_.analysis(...)`` (use
+            for LETKF's ``state_coords`` / ``obs_coords``).
+
+    Returns:
+        ``(loss, dynamics_grad)`` where ``loss`` is the summed
+        observation-space negative log-likelihood and ``dynamics_grad``
+        is a PyTree of the same structure as ``dynamics`` (only its
+        array leaves carry gradients; static / non-array fields are
+        ``None``-like via ``eqx.filter_value_and_grad``).
+    """
+    # Use a deterministic default filter; import here to avoid circular import.
+    if filter_ is None:
+        from filterax._src.sequential import ETKF
+
+        filter_ = ETKF()
+    _reject_stochastic_components(filter_, inflator)
+    if observations.shape[0] != obs_times.shape[0]:
+        raise ValueError(
+            "observations and obs_times must have the same leading axis; "
+            f"got {observations.shape[0]} and {obs_times.shape[0]}."
+        )
+
+    T = int(observations.shape[0])
+
+    def local_step(
+        dyn: AbstractDynamics,
+        ensemble: Float[Array, "N_e N_x"],
+        t_prev: Float[Array, ""],
+        t_now: Float[Array, ""],
+        obs_t: Float[Array, " N_y"],
+    ) -> tuple[Float[Array, ""], Float[Array, "N_e N_x"]]:
+        """One forecast + analysis with gradient tape on ``dyn`` only."""
+        forecast = _forecast(dyn, ensemble, t_prev, t_now)
+        result = filter_.analysis(forecast, obs_t, obs_op, obs_noise, **analysis_extra)
+        analysis_particles = result.particles
+        if inflator is not None:
+            analysis_particles = inflator(analysis_particles, forecast)
+        # Every deterministic filter returns a log-likelihood; the protocol's
+        # ``Array | None`` slot exists for future stochastic variants.
+        log_lik = result.log_likelihood
+        if log_lik is None:
+            log_lik = jnp.full((), jnp.nan, dtype=ensemble.dtype)
+        return -log_lik, analysis_particles
+
+    # ``filter_value_and_grad`` with ``has_aux`` returns the analysis
+    # particles alongside the local loss, so we don't recompute the
+    # forecast + analysis to advance the carry.
+    grad_step = eqx.filter_value_and_grad(local_step, has_aux=True)
+
+    # Unify the time dtype so the per-step ``t_prev`` carry stays consistent
+    # regardless of caller-supplied dtypes — mirrors the same fix in
+    # ``differentiable_assimilate``.
+    t0_arr = jnp.asarray(t0)
+    time_dtype = jnp.result_type(t0_arr, obs_times)
+    t0_arr = t0_arr.astype(time_dtype)
+    obs_times = obs_times.astype(time_dtype)
+
+    # Seed the gradient accumulator with the right pytree shape (zeros over
+    # array leaves of ``dynamics``; non-array leaves stay as-is and are
+    # ignored by ``filter_value_and_grad``).
+    total_grad: PyTree = jax.tree.map(
+        lambda leaf: jnp.zeros_like(leaf) if eqx.is_array(leaf) else None,
+        eqx.filter(dynamics, eqx.is_array),
+    )
+    total_loss = jnp.asarray(0.0, dtype=init_ensemble.dtype)
+    ensemble = init_ensemble
+    t_prev = t0_arr
+
+    # Python loop — each iteration carries its own short backward-pass
+    # tape; ``stop_gradient`` between iterations is what keeps memory
+    # at ``O(Nₑ · Nₓ)`` regardless of ``T``.
+    for t in range(T):
+        t_now = obs_times[t]
+        (loss_t, analysis_particles), grad_t = grad_step(
+            dynamics, ensemble, t_prev, t_now, observations[t]
+        )
+        total_loss = total_loss + loss_t
+        total_grad = jax.tree.map(
+            lambda acc, g: acc if g is None else acc + g, total_grad, grad_t
+        )
+        ensemble = jax.lax.stop_gradient(analysis_particles)
+        t_prev = t_now
+
+    return total_loss, total_grad
+
+
+def road_enkf_grad_step(
+    dynamics: AbstractDynamics,
+    optimizer: optax.GradientTransformation,
+    opt_state: optax.OptState,
+    init_ensemble: Float[Array, "N_e N_x"],
+    observations: Float[Array, "T N_y"],
+    obs_times: Float[Array, " T"],
+    obs_noise: lx.AbstractLinearOperator,
+    obs_op: AbstractObsOperator,
+    *,
+    filter_: AbstractSequentialFilter | None = None,
+    inflator: AbstractInflator | None = None,
+    t0: float | Float[Array, ""] = 0.0,
+    **analysis_extra: Any,
+) -> tuple[AbstractDynamics, optax.OptState, Float[Array, ""]]:
+    """One ROAD-EnKF descent step composed with an :mod:`optax` optimizer.
+
+    Convenience wrapper that runs :func:`road_enkf_loss_and_grad`, threads
+    the gradient through ``optimizer.update``, and applies the updates
+    to the dynamics module. Returns ``(new_dynamics, new_opt_state, loss)``
+    so the caller can log loss and continue the training loop.
+
+    Args:
+        dynamics: Forward model to update.
+        optimizer: Any ``optax.GradientTransformation``
+            (``optax.adam(1e-3)``, ``optax.chain(...)``, …).
+        opt_state: Optimizer state produced by ``optimizer.init(dynamics)``.
+        init_ensemble: Prior ensemble ``(Nₑ, Nₓ)``.
+        observations: Stacked observation history ``(T, Nᵧ)``.
+        obs_times: Stacked timestamps ``(T,)``.
+        obs_noise: Observation error covariance ``R``.
+        obs_op: Observation operator ``H``.
+        filter_: Deterministic L1 filter (default ``ETKF``).
+        inflator: Optional deterministic inflator.
+        t0: Starting time used for the first forecast window.
+        **analysis_extra: Forwarded to ``filter_.analysis(...)``.
+
+    Returns:
+        ``(new_dynamics, new_opt_state, loss)`` — the updated module,
+        the advanced optimizer state, and the loss at the current
+        ``dynamics``.
+    """
+    loss, grads = road_enkf_loss_and_grad(
+        dynamics,
+        init_ensemble,
+        observations,
+        obs_times,
+        obs_noise,
+        obs_op,
+        filter_=filter_,
+        inflator=inflator,
+        t0=t0,
+        **analysis_extra,
+    )
+    # Pass only the array leaves of ``dynamics`` to optax (matches what
+    # ``optimizer.init(eqx.filter(dynamics, eqx.is_array))`` consumes; otherwise
+    # optax's static type for ``params`` rejects the bare ``eqx.Module``).
+    params = eqx.filter(dynamics, eqx.is_array)
+    updates, new_opt_state = optimizer.update(grads, opt_state, params)
+    new_dynamics = eqx.apply_updates(dynamics, updates)
+    return new_dynamics, new_opt_state, loss

--- a/src/filterax/differentiable/__init__.py
+++ b/src/filterax/differentiable/__init__.py
@@ -1,0 +1,25 @@
+"""Differentiable data-assimilation surface.
+
+Two gradient strategies for training through the filter:
+
+* :func:`differentiable_assimilate` — fixed-shape :func:`jax.lax.scan`
+  with the full forward+backward tape (optional :func:`jax.checkpoint`
+  for ``O(√T)`` memory). Use when you want exact gradients including
+  cross-time terms.
+* :func:`road_enkf_loss_and_grad` / :func:`road_enkf_grad_step` —
+  ROAD-EnKF local-gradient strategy with :func:`jax.lax.stop_gradient`
+  between cycles. Backward-pass memory ``O(Nₑ · Nₓ)`` independent of
+  ``T``; drops cross-time gradient terms.
+
+Both refuse stochastic filters (``StochasticEnKF``, ``ETKF_Livings``)
+and the stochastic ``AdditiveInflator`` at call time — see
+``design_docs/features/differentiable_da.md`` §5.2 / §5.5.
+"""
+
+from filterax._src.differentiable import (
+    differentiable_assimilate as differentiable_assimilate,
+)
+from filterax._src.road import (
+    road_enkf_grad_step as road_enkf_grad_step,
+    road_enkf_loss_and_grad as road_enkf_loss_and_grad,
+)

--- a/tests/test_road.py
+++ b/tests/test_road.py
@@ -262,11 +262,13 @@ def test_road_jit_compiles(getkey):
 
 
 def test_road_long_horizon_compiles(getkey):
-    """ROAD's ``O(1)``-per-step backward-pass tape lets a long ``T``
-    compile that would be unwieldy under full-tape backprop. Smoke check
-    at ``T = 30``."""
+    """ROAD's per-step ``O(Nₑ · Nₓ)`` backward-pass tape plus the
+    ``lax.scan`` body keep both compile time and runtime memory
+    ``O(1)`` in ``T``. Smoke-check at ``T = 200`` — the Python-loop
+    predecessor of this implementation would have unrolled the JIT
+    trace to ``O(T · single_step_size)``."""
     particles, _, _, obs_op, R = _setup(getkey, T=4)
-    T = 30
+    T = 200
     obs = jr.normal(getkey(), (T, 2))
     times = jnp.arange(1.0, T + 1.0)
     dyn = _LinearDynamics(M=jnp.eye(particles.shape[1]))

--- a/tests/test_road.py
+++ b/tests/test_road.py
@@ -169,7 +169,7 @@ def test_road_grad_step_with_optax_optimizer():
 
     dyn = _LinearDynamics(M=1.1 * jnp.eye(N_x))
     optimizer = optax.adam(0.05)
-    opt_state = optimizer.init(eqx.filter(dyn, eqx.is_array))
+    opt_state = optimizer.init(eqx.filter(dyn, eqx.is_inexact_array))
 
     losses = []
     for _ in range(5):
@@ -178,6 +178,45 @@ def test_road_grad_step_with_optax_optimizer():
         )
         losses.append(float(loss))
     assert losses[-1] < losses[0]
+
+
+def test_road_skips_integer_array_leaves():
+    """Regression for the gradient-accumulator predicate: a dynamics
+    module carrying an integer index leaf alongside a trainable float
+    matrix must produce a ``None`` slot for the integer leaf so optax
+    can't try to write float updates onto it."""
+
+    class _IndexedDynamics(flx.AbstractDynamics):
+        M: jnp.ndarray  # trainable
+        obs_indices: jnp.ndarray  # non-trainable int metadata
+
+        def __call__(self, state, t0, t1):
+            # `obs_indices` is carried but never differentiated.
+            return self.M @ state
+
+    N_e, N_x, N_y, T = 12, 3, 2, 3
+    particles = jr.normal(jr.PRNGKey(4), (N_e, N_x))
+    obs = jr.normal(jr.PRNGKey(5), (T, N_y))
+    times = jnp.arange(1.0, T + 1.0)
+    H = jnp.eye(N_y, N_x)
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.1))
+    dyn = _IndexedDynamics(M=jnp.eye(N_x), obs_indices=jnp.arange(N_y, dtype=jnp.int32))
+    _, grads = flx.differentiable.road_enkf_loss_and_grad(
+        dyn, particles, obs, times, R, obs_op
+    )
+    assert grads.M is not None
+    assert grads.obs_indices is None
+    # And the full optimizer-update path doesn't choke on the int leaf.
+    optimizer = optax.adam(0.01)
+    opt_state = optimizer.init(eqx.filter(dyn, eqx.is_inexact_array))
+    new_dyn, _, _ = flx.differentiable.road_enkf_grad_step(
+        dyn, optimizer, opt_state, particles, obs, times, R, obs_op
+    )
+    # Integer field stayed untouched.
+    np.testing.assert_array_equal(
+        np.asarray(new_dyn.obs_indices), np.asarray(dyn.obs_indices)
+    )
 
 
 def test_road_grad_step_with_optax_chain():
@@ -193,7 +232,7 @@ def test_road_grad_step_with_optax_chain():
 
     dyn = _LinearDynamics(M=jnp.eye(2))
     optimizer = optax.chain(optax.clip_by_global_norm(1.0), optax.adam(0.01))
-    opt_state = optimizer.init(eqx.filter(dyn, eqx.is_array))
+    opt_state = optimizer.init(eqx.filter(dyn, eqx.is_inexact_array))
 
     dyn, opt_state, loss = flx.differentiable.road_enkf_grad_step(
         dyn, optimizer, opt_state, particles, obs, times, R, obs_op

--- a/tests/test_road.py
+++ b/tests/test_road.py
@@ -1,0 +1,311 @@
+"""Tests for the ROAD-EnKF local-gradient training surface.
+
+Two layers of coverage:
+
+1. **Algebraic correctness** — at ``T = 1`` ROAD-EnKF has no cross-time
+   terms to drop, so its loss + gradient must equal what
+   :func:`differentiable_assimilate` + :func:`jax.value_and_grad`
+   produces from the full-tape path. Provides a tight algebraic pin.
+2. **Differentiable-DA smoke** — gradient descent through ROAD-EnKF
+   moves a learnable scalar dynamics parameter the right way; the
+   convenience ``road_enkf_grad_step`` integrates with an ``optax``
+   optimiser; JIT + grad compose; stochastic components are rejected.
+
+All assertions are correctness invariants. No Monte-Carlo convergence.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+import numpy as np
+import optax
+import pytest
+
+import filterax as flx
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers (mirror tests/test_differentiable.py)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _LinearObs(flx.AbstractObsOperator):
+    H: jnp.ndarray
+
+    def __call__(self, state):
+        return self.H @ state
+
+
+class _IdentityDynamics(flx.AbstractDynamics):
+    def __call__(self, state, t0, t1):
+        return state
+
+
+class _LinearDynamics(flx.AbstractDynamics):
+    M: jnp.ndarray
+
+    def __call__(self, state, t0, t1):
+        return self.M @ state
+
+
+def _setup(getkey, T: int = 4, N_e: int = 20, N_x: int = 3, N_y: int = 2):
+    """Same shape as the differentiable-assimilate test fixture."""
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.zeros((N_y, N_x)).at[jnp.arange(N_y), jnp.arange(N_y)].set(1.0)
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.1))
+    obs = jr.normal(getkey(), (T, N_y))
+    times = jnp.arange(1.0, T + 1.0)
+    return particles, obs, times, obs_op, R
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Algebraic parity: T=1 ROAD matches full-tape value_and_grad
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_road_one_step_matches_full_value_and_grad(getkey):
+    """At ``T = 1`` ROAD has no cross-time terms to drop, so its loss and
+    gradient must equal the full-tape ``differentiable_assimilate``
+    path under :func:`jax.value_and_grad`."""
+    particles, obs, times, obs_op, R = _setup(getkey, T=1)
+
+    def full_loss(dyn):
+        result = flx.differentiable_assimilate(
+            flx.filters.ETKF(), dyn, obs_op, particles, obs, times, R
+        )
+        return -jnp.sum(result.log_likelihoods)
+
+    init_M = 0.95 * jnp.eye(particles.shape[1])
+    dyn = _LinearDynamics(M=init_M)
+
+    full_loss_val, full_grad = eqx.filter_value_and_grad(full_loss)(dyn)
+    road_loss_val, road_grad = flx.differentiable.road_enkf_loss_and_grad(
+        dyn, particles, obs, times, R, obs_op
+    )
+
+    np.testing.assert_allclose(float(road_loss_val), float(full_loss_val), atol=1e-10)
+    np.testing.assert_allclose(
+        np.asarray(road_grad.M), np.asarray(full_grad.M), atol=1e-10
+    )
+
+
+def test_road_grad_structure_matches_dynamics_pytree(getkey):
+    """The gradient PyTree mirrors the dynamics PyTree — every array leaf
+    has a same-shape gradient leaf; static fields are filtered out."""
+    particles, obs, times, obs_op, R = _setup(getkey)
+    dyn = _LinearDynamics(M=jnp.eye(particles.shape[1]))
+    _, grads = flx.differentiable.road_enkf_loss_and_grad(
+        dyn, particles, obs, times, R, obs_op
+    )
+    assert grads.M.shape == dyn.M.shape
+    assert grads.M.dtype == dyn.M.dtype
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Smoke: training pattern works end-to-end
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_road_pattern_a_descent_reduces_loss():
+    """Same Pattern A toy as ``test_pattern_a_learn_dynamics_params`` —
+    true ``M = 0.95 I``, starting at ``M = 1.0 I``. One ROAD-EnKF
+    descent step must reduce the loss."""
+    N_e, N_x, N_y, T = 20, 2, 2, 6
+    rng = np.random.default_rng(0)
+    truth = np.zeros((T, N_x))
+    state = np.array([1.0, -0.5])
+    H_np = np.eye(N_y, N_x)
+    for t in range(T):
+        state = 0.95 * state
+        truth[t] = state
+    obs = jnp.asarray(truth @ H_np.T + 0.05 * rng.standard_normal((T, N_y)))
+    times = jnp.arange(1.0, T + 1.0)
+    particles = jnp.asarray(rng.standard_normal((N_e, N_x))) + jnp.array([1.0, -0.5])
+    H = jnp.eye(N_y, N_x)
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.05**2))
+
+    dyn_init = _LinearDynamics(M=jnp.eye(N_x))
+    loss_init, grads = flx.differentiable.road_enkf_loss_and_grad(
+        dyn_init, particles, obs, times, R, obs_op
+    )
+    # Normalise the gradient before stepping — the raw gradient on the
+    # full ``M`` matrix has large norm in some entries and a fixed-step
+    # update overshoots the local quadratic. A unit-norm descent step is
+    # what proves the gradient direction is correct without depending on
+    # the loss-surface curvature.
+    grad_norm = jnp.linalg.norm(grads.M)
+    step = 0.01
+    dyn_after = eqx.tree_at(
+        lambda d: d.M, dyn_init, dyn_init.M - step * grads.M / grad_norm
+    )
+    loss_after, _ = flx.differentiable.road_enkf_loss_and_grad(
+        dyn_after, particles, obs, times, R, obs_op
+    )
+    assert float(loss_after) < float(loss_init)
+
+
+def test_road_grad_step_with_optax_optimizer():
+    """``road_enkf_grad_step`` composes with an :mod:`optax` optimiser —
+    multi-step descent reduces the loss."""
+    N_e, N_x, N_y, T = 16, 2, 2, 6
+    rng = np.random.default_rng(1)
+    truth = np.zeros((T, N_x))
+    state = np.array([1.0, -0.5])
+    for t in range(T):
+        state = 0.9 * state
+        truth[t] = state
+    H_np = np.eye(N_y, N_x)
+    obs = jnp.asarray(truth @ H_np.T + 0.05 * rng.standard_normal((T, N_y)))
+    times = jnp.arange(1.0, T + 1.0)
+    particles = jnp.asarray(rng.standard_normal((N_e, N_x))) + jnp.array([1.0, -0.5])
+    H = jnp.eye(N_y, N_x)
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.05**2))
+
+    dyn = _LinearDynamics(M=1.1 * jnp.eye(N_x))
+    optimizer = optax.adam(0.05)
+    opt_state = optimizer.init(eqx.filter(dyn, eqx.is_array))
+
+    losses = []
+    for _ in range(5):
+        dyn, opt_state, loss = flx.differentiable.road_enkf_grad_step(
+            dyn, optimizer, opt_state, particles, obs, times, R, obs_op
+        )
+        losses.append(float(loss))
+    assert losses[-1] < losses[0]
+
+
+def test_road_grad_step_with_optax_chain():
+    """``road_enkf_grad_step`` works under ``optax.chain`` (gradient
+    clipping + Adam) — proves the gradient piping is standard-optax-
+    compatible."""
+    particles = jr.normal(jr.PRNGKey(2), (12, 2))
+    obs = jr.normal(jr.PRNGKey(3), (4, 1))
+    times = jnp.arange(1.0, 5.0)
+    H = jnp.asarray([[1.0, 0.0]])
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((1,), 0.1))
+
+    dyn = _LinearDynamics(M=jnp.eye(2))
+    optimizer = optax.chain(optax.clip_by_global_norm(1.0), optax.adam(0.01))
+    opt_state = optimizer.init(eqx.filter(dyn, eqx.is_array))
+
+    dyn, opt_state, loss = flx.differentiable.road_enkf_grad_step(
+        dyn, optimizer, opt_state, particles, obs, times, R, obs_op
+    )
+    assert jnp.isfinite(loss)
+    assert bool(jnp.all(jnp.isfinite(dyn.M)))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# JIT & memory sanity
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_road_jit_compiles(getkey):
+    particles, obs, times, obs_op, R = _setup(getkey)
+    dyn = _LinearDynamics(M=jnp.eye(particles.shape[1]))
+
+    @eqx.filter_jit
+    def run(d):
+        return flx.differentiable.road_enkf_loss_and_grad(
+            d, particles, obs, times, R, obs_op
+        )
+
+    loss, grads = run(dyn)
+    assert jnp.isfinite(loss)
+    assert bool(jnp.all(jnp.isfinite(grads.M)))
+
+
+def test_road_long_horizon_compiles(getkey):
+    """ROAD's ``O(1)``-per-step backward-pass tape lets a long ``T``
+    compile that would be unwieldy under full-tape backprop. Smoke check
+    at ``T = 30``."""
+    particles, _, _, obs_op, R = _setup(getkey, T=4)
+    T = 30
+    obs = jr.normal(getkey(), (T, 2))
+    times = jnp.arange(1.0, T + 1.0)
+    dyn = _LinearDynamics(M=jnp.eye(particles.shape[1]))
+    loss, grads = flx.differentiable.road_enkf_loss_and_grad(
+        dyn, particles, obs, times, R, obs_op
+    )
+    assert jnp.isfinite(loss)
+    assert bool(jnp.all(jnp.isfinite(grads.M)))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Validation & dtype handling
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_road_rejects_stochastic_enkf(getkey):
+    particles, obs, times, obs_op, R = _setup(getkey)
+    dyn = _IdentityDynamics()
+    with pytest.raises(ValueError, match="StochasticEnKF"):
+        flx.differentiable.road_enkf_loss_and_grad(
+            dyn,
+            particles,
+            obs,
+            times,
+            R,
+            obs_op,
+            filter_=flx.filters.StochasticEnKF(0),
+        )
+
+
+def test_road_rejects_additive_inflator(getkey):
+    particles, obs, times, obs_op, R = _setup(getkey)
+    dyn = _IdentityDynamics()
+    inflator = flx.AdditiveInflator(
+        noise_cov=lx.DiagonalLinearOperator(jnp.full(particles.shape[1], 0.01)),
+        base_key=jr.PRNGKey(0),
+    )
+    with pytest.raises(ValueError, match="AdditiveInflator"):
+        flx.differentiable.road_enkf_loss_and_grad(
+            dyn,
+            particles,
+            obs,
+            times,
+            R,
+            obs_op,
+            inflator=inflator,
+        )
+
+
+def test_road_rejects_mismatched_obs_and_times(getkey):
+    particles, obs, times, obs_op, R = _setup(getkey, T=4)
+    dyn = _IdentityDynamics()
+    with pytest.raises(ValueError, match="same leading axis"):
+        flx.differentiable.road_enkf_loss_and_grad(
+            dyn,
+            particles,
+            obs,
+            times[:3],
+            R,
+            obs_op,
+        )
+
+
+def test_road_handles_mixed_time_dtypes(getkey):
+    """Same mixed-dtype regression as
+    ``test_diff_assimilate_handles_mixed_time_dtypes`` — integer obs
+    times paired with a float ensemble must trace cleanly."""
+    particles, obs, _, obs_op, R = _setup(getkey)
+    dyn = _LinearDynamics(M=jnp.eye(particles.shape[1]))
+    int_times = jnp.arange(1, obs.shape[0] + 1, dtype=jnp.int32)
+    loss, grads = flx.differentiable.road_enkf_loss_and_grad(
+        dyn,
+        particles,
+        obs,
+        int_times,
+        R,
+        obs_op,
+        t0=0,
+    )
+    assert jnp.isfinite(loss)
+    assert bool(jnp.all(jnp.isfinite(grads.M)))

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "filterax"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
Closes the long-horizon training memory gap left over from Wave 5.B (`design_docs/features/differentiable_da.md` §6.D, previously marked as a gap): ship the ROAD-EnKF (Chen et al. 2023) local-gradient strategy as a companion to `differentiable_assimilate`.

## Why

`differentiable_assimilate` keeps the full reverse-mode tape across `T` filter cycles — memory is `O(T · Nₑ · Nₓ)` (or `O(√T · Nₑ · Nₓ)` with `jax.checkpoint`). For training neural dynamics through filters on long observation windows, this is the bottleneck.

ROAD-EnKF takes a **per-step local gradient** with `jax.lax.stop_gradient` between cycles. Backward-pass memory stays `O(Nₑ · Nₓ)` independent of `T`. Trade-off: drops cross-time gradient terms (`∂L_t / ∂X^a_{t-1} · ∂X^a_{t-1} / ∂θ`). Accepted in the literature — the cross-time chain decays through filter stability, and memory savings dominate for long horizons.

## New surface

```python
from filterax.differentiable import road_enkf_loss_and_grad, road_enkf_grad_step

# Either: get loss + dynamics gradient directly
loss, dynamics_grad = road_enkf_loss_and_grad(
    dynamics, init_ensemble, observations, obs_times, R, obs_op,
)

# Or: one optax-flavoured descent step
new_dynamics, new_opt_state, loss = road_enkf_grad_step(
    dynamics, optimizer, opt_state, init_ensemble, observations, obs_times, R, obs_op,
)
```

- `filterax.differentiable` is now a subpackage re-exporting `differentiable_assimilate` alongside the two ROAD functions. Top-level `filterax.differentiable_assimilate` still works.
- Default `filter_=ETKF()` (deterministic, gradient-stable).
- Inherits the `_reject_stochastic_components` guard — refuses `StochasticEnKF` / `ETKF_Livings` / `AdditiveInflator`.
- LETKF's `state_coords` / `obs_coords` thread through via `**analysis_extra`.

## Upstream reference

Checked [ymchen0/ROAD-EnKF](https://github.com/ymchen0/ROAD-EnKF) per your suggestion. Findings:

| Upstream piece | filterax equivalent |
|---|---|
| `torchEnKF/da_methods.py::EnKF` — full forward + likelihood accumulation | `differentiable_assimilate` (full tape) + `road_enkf_loss_and_grad` (local) |
| `inv_logdet` — Woodbury solve for `(YYᵀ + R)⁻¹v` + logdet | gaussx `LowRankUpdate` + `solve_rows` (already used everywhere) |
| `construct_Gaspari_Cohn` | `filterax.gaspari_cohn` (already shipped) |
| `power_iter` for SV-based stability | not needed in this PR |
| `nn_templates.py` — spectral-conv obs/dynamics, Lorenz63 | application choices, leave to user via `AbstractObsOperator` / `AbstractDynamics` |
| PyTorch `odeint_adjoint` for adjoint memory | JAX equivalent is `diffrax` — orthogonal to ROAD's gradient strategy |

The novelty in our filterax port matches the design-doc shape in §6.D: local gradient + `stop_gradient` per step. No "goodies" missing from upstream — we're already structurally aligned via `gaussx`.

## Test plan (11 new tests, all algebraic / smoke)

- [x] **T=1 parity**: ROAD's loss + gradient equal the full-tape `differentiable_assimilate` + `jax.value_and_grad` output to atol `1e-10` (no cross-time terms to drop at T=1).
- [x] Gradient PyTree mirrors the dynamics PyTree (right shape, dtype).
- [x] **Pattern A descent**: unit-norm gradient step reduces the loss.
- [x] `road_enkf_grad_step` works with `optax.adam`; loss drops over 5 Adam steps (driving `M[0,0]` from 1.1 toward true 0.9).
- [x] `road_enkf_grad_step` works under `optax.chain(clip_by_global_norm, adam)`.
- [x] JIT + grad composes via `eqx.filter_jit`.
- [x] **T=30 long-horizon** compiles and produces finite gradients (smoke for the memory win).
- [x] Stochastic-component rejection inherited from the full-tape guard.
- [x] Mixed-dtype `obs_times` (int32) handled cleanly.
- [x] Full suite: **204 passed in 192s** (up from 193, no regressions).

## Design-doc patch

`features/differentiable_da.md` §6.D updated to mark ROAD-EnKF as **shipped** (was previously a gap), with the public API entry point spelled out.

## Follow-ups (not in this PR)

- **Latent space DA** primitive + `pipekit.Encoder` / `pipekit.Decoder` protocols (planned next, per the earlier conversation).
- Optional `loss_fn=...` parameter for CRPS / MSE / spread-skill alternatives to NLL (design doc §3 loss zoo).

https://claude.ai/code/session_01PPKxuHPad9k8wf3XsnKxvt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPKxuHPad9k8wf3XsnKxvt)_