### PR TITLE
feat(latent): add latent-space ensemble DA primitive (D17)

### DIFF
--- a/src/filterax/__init__.py
+++ b/src/filterax/__init__.py
@@ -23,6 +23,7 @@ from filterax._src._types import (
     AssimilationResult as AssimilationResult,
     FilterConfig as FilterConfig,
     FilterState as FilterState,
+    LatentAssimilationResult as LatentAssimilationResult,
     ProcessConfig as ProcessConfig,
     ProcessState as ProcessState,
     SmoothingResult as SmoothingResult,
@@ -46,6 +47,15 @@ from filterax._src.inflators import (
     AdditiveInflator as AdditiveInflator,
     MultiplicativeInflator as MultiplicativeInflator,
 )
+from filterax._src.latent import (
+    EncodedDynamics as EncodedDynamics,
+    IdentityLatentMap as IdentityLatentMap,
+    LatentDynamics as LatentDynamics,
+    LiftedObs as LiftedObs,
+    decode_ensemble as decode_ensemble,
+    identity_latent_map as identity_latent_map,
+    latent_ensemble as latent_ensemble,
+)
 from filterax._src.likelihood import (
     InnovationStatistics as InnovationStatistics,
     innovation_covariance as innovation_covariance,
@@ -64,6 +74,8 @@ from filterax._src.models import (
     ETKF as ETKF,
     LETKF as LETKF,
     EnSRF as EnSRF,
+    LatentETKF as LatentETKF,
+    LatentLETKF as LatentLETKF,
     StochasticEnKF as StochasticEnKF,
 )
 from filterax._src.perturbations import (

--- a/src/filterax/_src/_types.py
+++ b/src/filterax/_src/_types.py
@@ -66,6 +66,30 @@ class AssimilationResult(eqx.Module, strict=True):
     log_likelihoods: Float[Array, " T"] | None = None
 
 
+class LatentAssimilationResult(eqx.Module, strict=True):
+    """Output of a latent-space L2 assimilation loop.
+
+    Mirrors :class:`AssimilationResult` for the ``x``-space view
+    (``particles`` / ``forecast_history`` / ``analysis_history``)
+    while carrying the latent ensembles alongside. The ``_z`` fields
+    are the *primary* representation — the ``x``-space fields are
+    decoded views surfaced for ergonomics and for chaining into the
+    existing smoothers and diagnostics.
+
+    Identical-axis convention to :class:`AssimilationResult`:
+    histories stack along a leading ``T`` axis, ``particles`` is the
+    terminal ensemble for follow-up forecasts.
+    """
+
+    particles: Float[Array, "N_e N_x"]
+    forecast_history: Float[Array, "T N_e N_x"]
+    analysis_history: Float[Array, "T N_e N_x"]
+    log_likelihoods: Float[Array, " T"] | None
+    particles_z: Float[Array, "N_e N_z"]
+    forecast_history_z: Float[Array, "T N_e N_z"]
+    analysis_history_z: Float[Array, "T N_e N_z"]
+
+
 class SmoothingResult(eqx.Module, strict=True):
     """Output of a backward-pass ensemble smoother.
 

--- a/src/filterax/_src/latent.py
+++ b/src/filterax/_src/latent.py
@@ -1,0 +1,211 @@
+"""Latent-space ensemble Kalman filtering (Wave 5.C+).
+
+Implements decision D17 — latent ensemble DA via thin composition over
+the existing Layer-1 components, with no new analysis-step classes.
+The ensemble math (statistics, gain, localization, inflation) is
+unchanged; this module adds the wiring to run any deterministic
+square-root filter in a learned latent space ``ℝ^{N_z}`` and surface
+results back in ``ℝ^{N_x}``.
+
+Protocol expectations (duck-typed; no pipekit import per D11)
+-------------------------------------------------------------
+* **Encoder** — anything callable as ``encoder(x: Float[Array, " N_x"])
+  → Float[Array, " N_z"]`` (typically the ``.encode`` method on a
+  ``pipekit_cycle.LatentMap``).
+* **Decoder** — same shape for ``decoder(z) → x``.
+* **LatentMap** — an object exposing both ``.encode`` and ``.decode``.
+  :func:`identity_latent_map` is the canonical fixture; user
+  autoencoders satisfy this structurally.
+* **LatentForwardModel** — an object exposing ``.step(z, dt) → z``.
+
+Layer
+-----
+* Layer 0: :func:`latent_ensemble`, :func:`decode_ensemble`,
+  :func:`identity_latent_map`.
+* Layer 1: :class:`LatentDynamics`, :class:`LiftedObs`,
+  :class:`EncodedDynamics`.
+* Layer 2: :class:`filterax.LatentETKF`, :class:`filterax.LatentLETKF`
+  (in :mod:`filterax._src.models`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from filterax._src._protocols import (
+    AbstractDynamics,
+    AbstractObsOperator,
+)
+
+
+def latent_ensemble(
+    encoder: Any,
+    x_ensemble: Float[Array, "N_e N_x"],
+) -> Float[Array, "N_e N_z"]:
+    """Encode each ensemble member into latent space.
+
+    ``vmap``s the encoder over the ensemble leading axis. The encoder
+    is anything callable as ``encoder(x) → z`` — typically the
+    ``.encode`` method bound off a :class:`pipekit_cycle.LatentMap` or
+    a bare encoder ``eqx.Module``.
+
+    Args:
+        encoder: Callable ``x → z``.
+        x_ensemble: ``(Nₑ, Nₓ)`` ensemble in state space.
+
+    Returns:
+        ``(Nₑ, N_z)`` ensemble in latent space.
+    """
+    return eqx.filter_vmap(encoder)(x_ensemble)
+
+
+def decode_ensemble(
+    decoder: Any,
+    z_ensemble: Float[Array, "N_e N_z"],
+) -> Float[Array, "N_e N_x"]:
+    """Decode each ensemble member back into state space.
+
+    Mirror of :func:`latent_ensemble` for the decode direction.
+
+    Args:
+        decoder: Callable ``z → x``.
+        z_ensemble: ``(Nₑ, N_z)`` ensemble in latent space.
+
+    Returns:
+        ``(Nₑ, Nₓ)`` ensemble in state space.
+    """
+    return eqx.filter_vmap(decoder)(z_ensemble)
+
+
+class IdentityLatentMap(eqx.Module, strict=True):
+    r"""``φ = ψ = id`` regression-test fixture.
+
+    Used to verify that the latent filters reduce to their state-space
+    counterparts when the codec is the identity — pinning the wrapping
+    layer without depending on a real autoencoder. Carries a single
+    static ``dim`` field so callers can sanity-check shapes.
+    """
+
+    dim: int = eqx.field(static=True)
+
+    def encode(self, x: Float[Array, " N_x"]) -> Float[Array, " N_x"]:
+        return x
+
+    def decode(self, z: Float[Array, " N_x"]) -> Float[Array, " N_x"]:
+        return z
+
+
+def identity_latent_map(dim: int) -> IdentityLatentMap:
+    """Construct an :class:`IdentityLatentMap` of the given dimension.
+
+    The returned object satisfies the structural ``LatentMap`` contract
+    (``.encode`` + ``.decode``) and is the canonical fixture for
+    regression tests that pin :class:`filterax.LatentETKF` to plain
+    :class:`filterax.ETKF`.
+
+    Args:
+        dim: Common state / latent dimension.
+
+    Returns:
+        Pass-through latent map.
+    """
+    return IdentityLatentMap(dim=dim)
+
+
+class LatentDynamics(AbstractDynamics, strict=True):
+    r"""Wrap a structural ``LatentForwardModel`` as an ``AbstractDynamics``.
+
+    The wrapped object only needs a ``.step(z, dt)`` method; nothing
+    else about its type is constrained (no ``isinstance`` check). The
+    wrapper exists so the latent dynamics can drop into any existing
+    Layer-2 forecast loop alongside other ``AbstractDynamics``
+    instances.
+
+    Attributes:
+        inner: The wrapped latent forward model.
+    """
+
+    inner: Any
+
+    def __call__(
+        self,
+        state: Float[Array, " N_z"],
+        t0: Float[Array, ""],
+        t1: Float[Array, ""],
+    ) -> Float[Array, " N_z"]:
+        return self.inner.step(state, t1 - t0)
+
+
+class LiftedObs(AbstractObsOperator, strict=True):
+    r"""Compose a decoder with an ``x``-space observation operator.
+
+    Maps ``z → y`` via ``z ─ψ→ x ─H→ y``. Satisfies
+    :class:`AbstractObsOperator`, so it slots into ETKF / EnSRF /
+    LETKF / EnKS without changes — they only ever see the
+    ``(N_z, N_y)`` interface and don't care what's inside.
+
+    Attributes:
+        decoder: Anything callable as ``decoder.decode(z) → x``.
+        inner: Standard ``x``-space observation operator.
+    """
+
+    decoder: Any
+    inner: AbstractObsOperator
+
+    def __call__(self, state: Float[Array, " N_z"]) -> Float[Array, " N_y"]:
+        return self.inner(self.decoder.decode(state))
+
+
+class EncodedDynamics(AbstractDynamics, strict=True):
+    r"""Lift an ``x``-space dynamics into ``z``-space via codec round-trip.
+
+    For users with an ``x``-space :class:`AbstractDynamics` (a physics
+    model or a ``diffrax`` ODE wrapper) but no learned ``M_z``. One
+    ensemble step costs ``decode → inner → encode``. Used as the
+    ``dynamics`` argument to :class:`filterax.LatentETKF` when no
+    latent dynamics is available.
+
+    Attributes:
+        latent_map: ``.encode`` / ``.decode`` codec.
+        inner: ``x``-space dynamics.
+    """
+
+    latent_map: Any
+    inner: AbstractDynamics
+
+    def __call__(
+        self,
+        state: Float[Array, " N_z"],
+        t0: Float[Array, ""],
+        t1: Float[Array, ""],
+    ) -> Float[Array, " N_z"]:
+        x = self.latent_map.decode(state)
+        x_next = self.inner(x, t0, t1)
+        return self.latent_map.encode(x_next)
+
+
+def _stack_decode(
+    decoder: Any, z_history: Float[Array, "T N_e N_z"]
+) -> Float[Array, "T N_e N_x"]:
+    """Decode every member of a ``(T, Nₑ, N_z)`` history into ``x``-space.
+
+    Used internally by the Layer-2 latent wrappers to surface the
+    latent ``analysis_history`` / ``forecast_history`` in state space
+    while keeping the latent representations on the side. Implemented
+    as a Python ``for`` over the time axis so the inner ``decode_ensemble``
+    can keep its ensemble-axis ``vmap`` semantics; ``T`` is small.
+    """
+    T = z_history.shape[0]
+    if T == 0:
+        # Probe the decoder once to learn ``N_x`` and return an empty
+        # ``(0, N_e, N_x)`` so the result shape stays consistent with the
+        # non-empty case.
+        N_e, N_z = z_history.shape[1], z_history.shape[2]
+        probe = jnp.zeros((N_e, N_z), dtype=z_history.dtype)
+        N_x = decode_ensemble(decoder, probe).shape[-1]
+        return jnp.empty((0, N_e, N_x), dtype=z_history.dtype)
+    return jnp.stack([decode_ensemble(decoder, z_history[t]) for t in range(T)])

--- a/src/filterax/_src/models.py
+++ b/src/filterax/_src/models.py
@@ -40,6 +40,7 @@ from filterax._src._types import (
     LatentAssimilationResult,
 )
 from filterax._src.latent import (
+    LatentDynamics,
     LiftedObs,
     _stack_decode,
     decode_ensemble,
@@ -300,6 +301,22 @@ class LETKF(eqx.Module, strict=True):
 # ──────────────────────────────────────────────────────────────────────
 
 
+def _coerce_latent_dynamics(d: Any) -> AbstractDynamics:
+    """Auto-wrap a structural ``LatentForwardModel`` as an ``AbstractDynamics``.
+
+    The design doc advertises both the wrapped form (any
+    :class:`AbstractDynamics` — typically :class:`LatentDynamics` or
+    :class:`EncodedDynamics`) and the raw structural form (any object
+    with ``.step(z, dt) → z``). The L2 wrappers feed the dynamics
+    into :func:`_forecast`, which calls ``dynamics(state, t0, t1)`` —
+    so a raw ``.step``-only object would raise at trace time. We wrap
+    here so users following either contract get the same ergonomics.
+    """
+    if isinstance(d, AbstractDynamics):
+        return d
+    return LatentDynamics(inner=d)
+
+
 def _wrap_latent_result(
     latent_map: Any,
     result_z: AssimilationResult,
@@ -342,8 +359,12 @@ class LatentETKF(eqx.Module, strict=True):
         latent_map: Object exposing ``.encode`` and ``.decode``.
             Typically a :class:`pipekit_cycle.LatentMap`-shaped autoencoder
             or :func:`identity_latent_map` for regression tests.
-        dynamics: Latent-space dynamics — usually a
-            :class:`LatentDynamics` or :class:`EncodedDynamics`.
+        dynamics: Latent-space dynamics — either an
+            :class:`AbstractDynamics` (typically :class:`LatentDynamics`
+            or :class:`EncodedDynamics`) or a structural
+            ``LatentForwardModel`` exposing ``.step(z, dt) → z``. Raw
+            ``.step``-only objects are auto-wrapped in
+            :class:`LatentDynamics` at construction.
         obs_op: ``x``-space observation operator. Lifted internally
             via :class:`LiftedObs`.
         inflator: Optional deterministic inflator applied in latent
@@ -354,8 +375,22 @@ class LatentETKF(eqx.Module, strict=True):
     latent_map: Any
     dynamics: AbstractDynamics
     obs_op: AbstractObsOperator
-    inflator: AbstractInflator | None = None
-    config: FilterConfig | None = None
+    inflator: AbstractInflator | None
+    config: FilterConfig | None
+
+    def __init__(
+        self,
+        latent_map: Any,
+        dynamics: Any,
+        obs_op: AbstractObsOperator,
+        inflator: AbstractInflator | None = None,
+        config: FilterConfig | None = None,
+    ):
+        self.latent_map = latent_map
+        self.dynamics = _coerce_latent_dynamics(dynamics)
+        self.obs_op = obs_op
+        self.inflator = inflator
+        self.config = config
 
     def assimilate(
         self,
@@ -417,13 +452,32 @@ class LatentLETKF(eqx.Module, strict=True):
     name that they can wire into pipekit alongside ``LatentETKF``
     without having to fall back to ``LatentETKF`` themselves. The
     body is identical to :class:`LatentETKF`.
+
+    Like :class:`LatentETKF`, ``dynamics`` may be either an
+    :class:`AbstractDynamics` or a raw structural ``LatentForwardModel``
+    (``.step(z, dt) → z``); the latter is auto-wrapped in
+    :class:`LatentDynamics` at construction.
     """
 
     latent_map: Any
     dynamics: AbstractDynamics
     obs_op: AbstractObsOperator
-    inflator: AbstractInflator | None = None
-    config: FilterConfig | None = None
+    inflator: AbstractInflator | None
+    config: FilterConfig | None
+
+    def __init__(
+        self,
+        latent_map: Any,
+        dynamics: Any,
+        obs_op: AbstractObsOperator,
+        inflator: AbstractInflator | None = None,
+        config: FilterConfig | None = None,
+    ):
+        self.latent_map = latent_map
+        self.dynamics = _coerce_latent_dynamics(dynamics)
+        self.obs_op = obs_op
+        self.inflator = inflator
+        self.config = config
 
     def assimilate(
         self,

--- a/src/filterax/_src/models.py
+++ b/src/filterax/_src/models.py
@@ -20,6 +20,7 @@ NaN so callers can index by window without re-aligning.
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -33,7 +34,17 @@ from filterax._src._protocols import (
     AbstractObsOperator,
     AbstractSequentialFilter,
 )
-from filterax._src._types import AssimilationResult, FilterConfig
+from filterax._src._types import (
+    AssimilationResult,
+    FilterConfig,
+    LatentAssimilationResult,
+)
+from filterax._src.latent import (
+    LiftedObs,
+    _stack_decode,
+    decode_ensemble,
+    latent_ensemble,
+)
 from filterax._src.sequential import (
     ETKF as _ETKFFilter,
     LETKF as _LETKFFilter,
@@ -282,3 +293,161 @@ class LETKF(eqx.Module, strict=True):
                 "obs_coords": obs_coords,
             },
         )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Latent-space L2 wrappers (D17)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _wrap_latent_result(
+    latent_map: Any,
+    result_z: AssimilationResult,
+) -> LatentAssimilationResult:
+    """Decode the z-space histories on a vanilla ``AssimilationResult``.
+
+    Used by :class:`LatentETKF` / :class:`LatentLETKF` to surface the
+    decoded ``x``-space view alongside the latent representations.
+    """
+    particles_x = decode_ensemble(latent_map.decode, result_z.particles)
+    forecast_x = _stack_decode(latent_map.decode, result_z.forecast_history)
+    analysis_x = _stack_decode(latent_map.decode, result_z.analysis_history)
+    return LatentAssimilationResult(
+        particles=particles_x,
+        forecast_history=forecast_x,
+        analysis_history=analysis_x,
+        log_likelihoods=result_z.log_likelihoods,
+        particles_z=result_z.particles,
+        forecast_history_z=result_z.forecast_history,
+        analysis_history_z=result_z.analysis_history,
+    )
+
+
+class LatentETKF(eqx.Module, strict=True):
+    r"""ETKF analysis applied to a latent-space ensemble (D17).
+
+    Thin composition over the existing :class:`ETKF` Layer-1 step:
+    encode the initial ensemble (when supplied in ``x``-space), run
+    the standard forecast → ETKF → optional inflation cycle on the
+    latent ensemble using ``LiftedObs(decoder, x_obs_op)`` as the
+    observation operator, then decode the histories back to
+    ``x``-space alongside the latent representations.
+
+    The ensemble math is unchanged — the wrapper exists for ergonomics
+    and for compile-time correctness (it would be hard to accidentally
+    feed an ``x``-space ensemble into a latent-space analysis step
+    once the user builds a ``LatentETKF``).
+
+    Attributes:
+        latent_map: Object exposing ``.encode`` and ``.decode``.
+            Typically a :class:`pipekit_cycle.LatentMap`-shaped autoencoder
+            or :func:`identity_latent_map` for regression tests.
+        dynamics: Latent-space dynamics — usually a
+            :class:`LatentDynamics` or :class:`EncodedDynamics`.
+        obs_op: ``x``-space observation operator. Lifted internally
+            via :class:`LiftedObs`.
+        inflator: Optional deterministic inflator applied in latent
+            space.
+        config: Reserved :class:`FilterConfig`.
+    """
+
+    latent_map: Any
+    dynamics: AbstractDynamics
+    obs_op: AbstractObsOperator
+    inflator: AbstractInflator | None = None
+    config: FilterConfig | None = None
+
+    def assimilate(
+        self,
+        init_ensemble: Float[Array, "N_e N_d"],
+        observations: Sequence[tuple[Float[Array, " N_y"], float | Float[Array, ""]]],
+        obs_noise: lx.AbstractLinearOperator,
+        t0: float | Float[Array, ""] = 0.0,
+        *,
+        in_x_space: bool = True,
+    ) -> LatentAssimilationResult:
+        """Run forecast → ETKF analysis → optional inflation in latent space.
+
+        Args:
+            init_ensemble: Prior ensemble. Shape ``(Nₑ, Nₓ)`` when
+                ``in_x_space=True`` (default); ``(Nₑ, N_z)`` when the
+                caller already encoded.
+            observations: Sequence of ``(y_t, t)`` pairs in
+                ``x``-space coordinates.
+            obs_noise: Observation error covariance ``R`` (operates in
+                ``y``-space, untouched).
+            t0: Starting time for the first forecast window.
+            in_x_space: Encode the initial ensemble first. ``False``
+                lets the caller skip the round-trip when their initial
+                ensemble already lives in ``z``-space.
+
+        Returns:
+            :class:`LatentAssimilationResult` carrying both the
+            latent and decoded ``x``-space ensembles.
+        """
+        z0 = (
+            latent_ensemble(self.latent_map.encode, init_ensemble)
+            if in_x_space
+            else init_ensemble
+        )
+        result_z = _run_loop(
+            lambda _step: _ETKFFilter(),
+            self.dynamics,
+            LiftedObs(decoder=self.latent_map, inner=self.obs_op),
+            self.inflator,
+            z0,
+            observations,
+            obs_noise,
+            t0,
+        )
+        return _wrap_latent_result(self.latent_map, result_z)
+
+
+class LatentLETKF(eqx.Module, strict=True):
+    r"""Local ETKF in latent space (D17).
+
+    Sister of :class:`LatentETKF` over :class:`LETKF`. v0.1 implements
+    option (a) of `latent_da.md` §9.2 — *no* localization in latent
+    space — because the latent dimensions of a typical autoencoder are
+    global modes without an intrinsic notion of locality.
+    Pseudo-localization-via-mode-coords (option c) is deferred.
+
+    For the no-localization case, this class is provided for API
+    parity with :class:`LatentETKF`: it gives users a ``LatentLETKF``
+    name that they can wire into pipekit alongside ``LatentETKF``
+    without having to fall back to ``LatentETKF`` themselves. The
+    body is identical to :class:`LatentETKF`.
+    """
+
+    latent_map: Any
+    dynamics: AbstractDynamics
+    obs_op: AbstractObsOperator
+    inflator: AbstractInflator | None = None
+    config: FilterConfig | None = None
+
+    def assimilate(
+        self,
+        init_ensemble: Float[Array, "N_e N_d"],
+        observations: Sequence[tuple[Float[Array, " N_y"], float | Float[Array, ""]]],
+        obs_noise: lx.AbstractLinearOperator,
+        t0: float | Float[Array, ""] = 0.0,
+        *,
+        in_x_space: bool = True,
+    ) -> LatentAssimilationResult:
+        """Run forecast → ETKF analysis (no localization) → inflation in z-space."""
+        z0 = (
+            latent_ensemble(self.latent_map.encode, init_ensemble)
+            if in_x_space
+            else init_ensemble
+        )
+        result_z = _run_loop(
+            lambda _step: _ETKFFilter(),
+            self.dynamics,
+            LiftedObs(decoder=self.latent_map, inner=self.obs_op),
+            self.inflator,
+            z0,
+            observations,
+            obs_noise,
+            t0,
+        )
+        return _wrap_latent_result(self.latent_map, result_z)

--- a/tests/test_latent.py
+++ b/tests/test_latent.py
@@ -336,6 +336,43 @@ def test_lifted_obs_satisfies_obs_operator_protocol():
     assert isinstance(enc_dyn, flx.AbstractDynamics)
 
 
+def test_latent_etkf_auto_wraps_raw_latent_forward_model(getkey):
+    # The design doc advertises the structural ``LatentForwardModel`` —
+    # ``.step(z, dt) → z`` only. The L2 wrappers must auto-wrap so a raw
+    # ``.step``-only object does not fail at trace time inside
+    # ``_forecast`` (which calls ``dynamics(state, t0, t1)``).
+    particles, obs_op, R, obs_seq = _make_obs_problem(getkey)
+    N_x = particles.shape[1]
+    lm = flx.identity_latent_map(dim=N_x)
+    raw = _LinearLatentForward(A=jnp.eye(N_x))
+
+    filt = flx.LatentETKF(latent_map=lm, dynamics=raw, obs_op=obs_op)
+    assert isinstance(filt.dynamics, flx.LatentDynamics)
+    assert filt.dynamics.inner is raw
+
+    out = filt.assimilate(particles, obs_seq, R)
+    assert out.particles.shape == particles.shape
+    assert bool(jnp.all(jnp.isfinite(out.particles)))
+
+    # An already-wrapped AbstractDynamics is passed through unchanged.
+    wrapped = flx.LatentDynamics(inner=raw)
+    filt_wrapped = flx.LatentETKF(latent_map=lm, dynamics=wrapped, obs_op=obs_op)
+    assert filt_wrapped.dynamics is wrapped
+
+
+def test_latent_letkf_auto_wraps_raw_latent_forward_model(getkey):
+    particles, obs_op, R, obs_seq = _make_obs_problem(getkey)
+    N_x = particles.shape[1]
+    lm = flx.identity_latent_map(dim=N_x)
+    raw = _LinearLatentForward(A=jnp.eye(N_x))
+
+    filt = flx.LatentLETKF(latent_map=lm, dynamics=raw, obs_op=obs_op)
+    assert isinstance(filt.dynamics, flx.LatentDynamics)
+    out = filt.assimilate(particles, obs_seq, R)
+    assert out.particles.shape == particles.shape
+    assert bool(jnp.all(jnp.isfinite(out.particles)))
+
+
 def test_latent_etkf_grad_skips_non_trainable_codec_fields(getkey):
     # ``identity_latent_map`` carries only a static ``int`` field, so
     # ``eqx.filter_grad`` should treat it as having no trainable leaves.

--- a/tests/test_latent.py
+++ b/tests/test_latent.py
@@ -1,0 +1,352 @@
+"""Latent-space ensemble DA (D17) — algebraic correctness + smoke tests.
+
+The wrapping layer adds no new ensemble math: identity-codec wrappers
+must match their state-space counterparts bit-for-bit; the L1 wrappers
+(:class:`LatentDynamics`, :class:`LiftedObs`, :class:`EncodedDynamics`)
+must satisfy the obvious round-trip identities under an identity codec.
+Differentiability and JIT compatibility are covered as smoke tests.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+import numpy as np
+
+import filterax as flx
+
+
+class _LinearObs(flx.AbstractObsOperator):
+    H: jnp.ndarray
+
+    def __call__(self, state):
+        return self.H @ state
+
+
+class _IdentityDynamics(flx.AbstractDynamics):
+    def __call__(self, state, t0, t1):
+        return state
+
+
+class _LinearXDynamics(flx.AbstractDynamics):
+    """Non-trivial ``x``-space linear dynamics ``xₙ₊₁ = A xₙ``."""
+
+    A: jnp.ndarray
+
+    def __call__(self, state, t0, t1):
+        return self.A @ state
+
+
+class _LinearLatentForward(eqx.Module):
+    """Toy ``LatentForwardModel`` — duck-typed ``.step(z, dt)`` only."""
+
+    A: jnp.ndarray
+
+    def step(self, z, dt):
+        del dt
+        return self.A @ z
+
+
+def _make_obs_problem(getkey, N_x=4, N_y=2, N_e=30, n_windows=2):
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.eye(N_x)[:N_y]
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.4))
+    obs_seq = [
+        (jr.normal(getkey(), (N_y,)) * 0.5, float(t + 1)) for t in range(n_windows)
+    ]
+    return particles, obs_op, R, obs_seq
+
+
+# ──────────────────────────────────────────────────────────────────────
+# L0: latent_ensemble, decode_ensemble, identity_latent_map
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_identity_latent_map_round_trip(getkey):
+    lm = flx.identity_latent_map(dim=4)
+    x = jr.normal(getkey(), (4,))
+    np.testing.assert_array_equal(np.asarray(lm.encode(x)), np.asarray(x))
+    np.testing.assert_array_equal(np.asarray(lm.decode(x)), np.asarray(x))
+
+
+def test_latent_ensemble_vmaps_encoder(getkey):
+    lm = flx.identity_latent_map(dim=3)
+    ens = jr.normal(getkey(), (5, 3))
+    np.testing.assert_array_equal(
+        np.asarray(flx.latent_ensemble(lm.encode, ens)), np.asarray(ens)
+    )
+
+
+def test_decode_ensemble_vmaps_decoder(getkey):
+    lm = flx.identity_latent_map(dim=3)
+    ens = jr.normal(getkey(), (5, 3))
+    np.testing.assert_array_equal(
+        np.asarray(flx.decode_ensemble(lm.decode, ens)), np.asarray(ens)
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# L1: LiftedObs, LatentDynamics, EncodedDynamics
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_lifted_obs_identity_decoder_matches_x_space(getkey):
+    H = jnp.asarray([[1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+    obs_op = _LinearObs(H=H)
+    lm = flx.identity_latent_map(dim=3)
+    lifted = flx.LiftedObs(decoder=lm, inner=obs_op)
+    x = jr.normal(getkey(), (3,))
+    np.testing.assert_allclose(np.asarray(lifted(x)), np.asarray(obs_op(x)), atol=1e-12)
+
+
+def test_encoded_dynamics_identity_codec_matches_inner(getkey):
+    A = jr.normal(getkey(), (4, 4))
+    inner = _LinearXDynamics(A=A)
+    lm = flx.identity_latent_map(dim=4)
+    wrapped = flx.EncodedDynamics(latent_map=lm, inner=inner)
+    x = jr.normal(getkey(), (4,))
+    t0, t1 = jnp.asarray(0.0), jnp.asarray(1.0)
+    np.testing.assert_allclose(
+        np.asarray(wrapped(x, t0, t1)),
+        np.asarray(inner(x, t0, t1)),
+        atol=1e-12,
+    )
+
+
+def test_latent_dynamics_delegates_to_inner_step(getkey):
+    A = jr.normal(getkey(), (3, 3))
+    inner = _LinearLatentForward(A=A)
+    wrapped = flx.LatentDynamics(inner=inner)
+    z = jr.normal(getkey(), (3,))
+    t0, t1 = jnp.asarray(0.5), jnp.asarray(1.5)
+    np.testing.assert_allclose(
+        np.asarray(wrapped(z, t0, t1)),
+        np.asarray(inner.step(z, t1 - t0)),
+        atol=1e-12,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# L2: identity-codec parity with ETKF / LETKF
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_latent_etkf_identity_codec_matches_etkf(getkey):
+    # With ``φ = ψ = id`` the latent wrapper must reproduce the
+    # plain ETKF posterior bit-for-bit at double precision.
+    particles, obs_op, R, obs_seq = _make_obs_problem(getkey)
+    N_x = particles.shape[1]
+    dynamics = _IdentityDynamics()
+
+    plain = flx.ETKF(dynamics=dynamics, obs_op=obs_op).assimilate(particles, obs_seq, R)
+    lm = flx.identity_latent_map(dim=N_x)
+    latent = flx.LatentETKF(latent_map=lm, dynamics=dynamics, obs_op=obs_op).assimilate(
+        particles, obs_seq, R
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(latent.particles), np.asarray(plain.particles), atol=1e-12
+    )
+    np.testing.assert_allclose(
+        np.asarray(latent.particles_z),
+        np.asarray(plain.particles),
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        np.asarray(latent.forecast_history),
+        np.asarray(plain.forecast_history),
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        np.asarray(latent.analysis_history),
+        np.asarray(plain.analysis_history),
+        atol=1e-12,
+    )
+    assert latent.log_likelihoods is not None
+    np.testing.assert_allclose(
+        np.asarray(latent.log_likelihoods),
+        np.asarray(plain.log_likelihoods),
+        atol=1e-12,
+    )
+
+
+def test_latent_letkf_identity_codec_matches_etkf(getkey):
+    # v0.1 has no localization in latent space (§9.2 option a), so
+    # ``LatentLETKF`` must collapse to plain ``ETKF`` under identity codec.
+    particles, obs_op, R, obs_seq = _make_obs_problem(getkey)
+    N_x = particles.shape[1]
+    dynamics = _IdentityDynamics()
+
+    plain = flx.ETKF(dynamics=dynamics, obs_op=obs_op).assimilate(particles, obs_seq, R)
+    lm = flx.identity_latent_map(dim=N_x)
+    latent = flx.LatentLETKF(
+        latent_map=lm, dynamics=dynamics, obs_op=obs_op
+    ).assimilate(particles, obs_seq, R)
+
+    np.testing.assert_allclose(
+        np.asarray(latent.particles), np.asarray(plain.particles), atol=1e-12
+    )
+    np.testing.assert_allclose(
+        np.asarray(latent.analysis_history),
+        np.asarray(plain.analysis_history),
+        atol=1e-12,
+    )
+
+
+def test_latent_etkf_in_x_space_false_accepts_pre_encoded_ensemble(getkey):
+    particles, obs_op, R, obs_seq = _make_obs_problem(getkey)
+    N_x = particles.shape[1]
+    lm = flx.identity_latent_map(dim=N_x)
+    dynamics = _IdentityDynamics()
+
+    res_x = flx.LatentETKF(latent_map=lm, dynamics=dynamics, obs_op=obs_op).assimilate(
+        particles, obs_seq, R, in_x_space=True
+    )
+    res_z = flx.LatentETKF(latent_map=lm, dynamics=dynamics, obs_op=obs_op).assimilate(
+        flx.latent_ensemble(lm.encode, particles), obs_seq, R, in_x_space=False
+    )
+    np.testing.assert_allclose(
+        np.asarray(res_x.particles_z),
+        np.asarray(res_z.particles_z),
+        atol=1e-12,
+    )
+
+
+def test_latent_etkf_result_shapes(getkey):
+    # Codec changes dimension: encoder ``ℝ^4 → ℝ^2``, decoder ``ℝ^2 → ℝ^4``.
+    N_e, N_x, N_z, N_y = 30, 4, 2, 2
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.eye(N_x)[:N_y]
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.4))
+    obs_seq = [(jr.normal(getkey(), (N_y,)) * 0.3, float(t + 1)) for t in range(2)]
+
+    class _Codec(eqx.Module):
+        W_enc: jnp.ndarray
+        W_dec: jnp.ndarray
+
+        def encode(self, x):
+            return self.W_enc @ x
+
+        def decode(self, z):
+            return self.W_dec @ z
+
+    lm = _Codec(
+        W_enc=jr.normal(getkey(), (N_z, N_x)),
+        W_dec=jr.normal(getkey(), (N_x, N_z)),
+    )
+    A_z = jr.normal(getkey(), (N_z, N_z))
+    dynamics = flx.LatentDynamics(inner=_LinearLatentForward(A=A_z))
+
+    res = flx.LatentETKF(latent_map=lm, dynamics=dynamics, obs_op=obs_op).assimilate(
+        particles, obs_seq, R
+    )
+
+    assert res.particles.shape == (N_e, N_x)
+    assert res.particles_z.shape == (N_e, N_z)
+    assert res.forecast_history.shape == (2, N_e, N_x)
+    assert res.forecast_history_z.shape == (2, N_e, N_z)
+    assert res.analysis_history.shape == (2, N_e, N_x)
+    assert res.analysis_history_z.shape == (2, N_e, N_z)
+    assert res.log_likelihoods is not None
+    assert res.log_likelihoods.shape == (2,)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Differentiability + JIT
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_latent_etkf_assimilate_is_jit_safe(getkey):
+    # ``LatentETKF.assimilate`` must compose cleanly with ``eqx.filter_jit``
+    # — observations are a Python list of tuples so the static structure is
+    # baked in at trace time, just like the other L2 wrappers.
+    particles, obs_op, R, obs_seq = _make_obs_problem(getkey)
+    N_x = particles.shape[1]
+    lm = flx.identity_latent_map(dim=N_x)
+    filter_ = flx.LatentETKF(latent_map=lm, dynamics=_IdentityDynamics(), obs_op=obs_op)
+
+    @eqx.filter_jit
+    def run(p):
+        return filter_.assimilate(p, obs_seq, R).particles
+
+    out = run(particles)
+    assert out.shape == particles.shape
+    assert bool(jnp.all(jnp.isfinite(out)))
+
+
+def test_latent_etkf_differentiable_wrt_codec_weights(getkey):
+    """Gradient w.r.t. trainable codec weights flows through the L2 loop.
+
+    Confirms the wrapping layer is end-to-end differentiable, which is
+    the whole point of the latent DA primitive — the user can train the
+    codec by backpropagating through the assimilation.
+    """
+    N_e, N_x = 20, 3
+    particles = jr.normal(getkey(), (N_e, N_x))
+    H = jnp.eye(N_x)[:2]
+    obs_op = _LinearObs(H=H)
+    R = lx.DiagonalLinearOperator(jnp.full((2,), 0.5))
+    obs_seq = [
+        (jr.normal(getkey(), (2,)) * 0.3, 1.0),
+        (jr.normal(getkey(), (2,)) * 0.3, 2.0),
+    ]
+
+    class _Codec(eqx.Module):
+        W: jnp.ndarray
+
+        def encode(self, x):
+            return self.W @ x
+
+        def decode(self, z):
+            return self.W.T @ z
+
+    lm0 = _Codec(W=jnp.eye(N_x))
+
+    def loss(lm):
+        filter_ = flx.LatentETKF(
+            latent_map=lm, dynamics=_IdentityDynamics(), obs_op=obs_op
+        )
+        out = filter_.assimilate(particles, obs_seq, R)
+        return jnp.mean(out.particles**2)
+
+    grads = eqx.filter_grad(loss)(lm0)
+    assert grads.W.shape == lm0.W.shape
+    assert bool(jnp.all(jnp.isfinite(grads.W)))
+    assert float(jnp.abs(grads.W).max()) > 0.0
+
+
+def test_lifted_obs_satisfies_obs_operator_protocol():
+    # Structural check: the wrapping classes must register as their
+    # abstract types so they slot into the existing filters and any
+    # ``isinstance`` checks in downstream code.
+    lm = flx.identity_latent_map(dim=2)
+    obs_op = _LinearObs(H=jnp.eye(2))
+    lifted = flx.LiftedObs(decoder=lm, inner=obs_op)
+    assert isinstance(lifted, flx.AbstractObsOperator)
+
+    dyn = flx.LatentDynamics(inner=_LinearLatentForward(A=jnp.eye(2)))
+    assert isinstance(dyn, flx.AbstractDynamics)
+
+    enc_dyn = flx.EncodedDynamics(latent_map=lm, inner=_IdentityDynamics())
+    assert isinstance(enc_dyn, flx.AbstractDynamics)
+
+
+def test_latent_etkf_grad_skips_non_trainable_codec_fields(getkey):
+    # ``identity_latent_map`` carries only a static ``int`` field, so
+    # ``eqx.filter_grad`` should treat it as having no trainable leaves.
+    particles, obs_op, R, obs_seq = _make_obs_problem(getkey)
+    N_x = particles.shape[1]
+    lm = flx.identity_latent_map(dim=N_x)
+    filter_ = flx.LatentETKF(latent_map=lm, dynamics=_IdentityDynamics(), obs_op=obs_op)
+
+    def loss(p):
+        return jnp.mean(filter_.assimilate(p, obs_seq, R).particles ** 2)
+
+    grad = jax.grad(loss)(particles)
+    assert grad.shape == particles.shape
+    assert bool(jnp.all(jnp.isfinite(grad)))


### PR DESCRIPTION
## Summary

Implements decision **D17 — Latent Ensemble Data Assimilation** per the design doc in `docs/design_docs/features/latent_da.md`. The wrapping layer is intentionally thin: no new analysis-step classes, no new ensemble math. Existing square-root filters drop into a learned latent space via a small set of L0 primitives and L1 wrappers.

### Surface

- **L0** — `latent_ensemble`, `decode_ensemble`, `identity_latent_map` / `IdentityLatentMap` regression-test fixture
- **L1** — `LatentDynamics` (wraps a duck-typed `LatentForwardModel`), `LiftedObs` (composes a decoder with an `x`-space observation operator), `EncodedDynamics` (lifts `x`-space dynamics into `z`-space via codec round-trip)
- **L2** — `LatentETKF` and `LatentLETKF` wrappers returning a new `LatentAssimilationResult` carrying both the latent ensembles (primary) and the decoded `x`-space view (for chaining into smoothers / diagnostics)

### Design notes

- The codec contract is duck-typed via `Any` per D11 — anything with `.encode` / `.decode` works (typically a `pipekit_cycle.LatentMap`) without filterax importing pipekit.
- `LatentLETKF` v0.1 implements option (a) of §9.2 — no localization in latent space — since autoencoder dimensions are global modes without an intrinsic notion of locality. Sister name kept for API parity so users can wire either filter into pipekit without a fallback.

### Test plan

`tests/test_latent.py` covers the §11 acceptance criteria (issue #87):

- [x] Identity-codec parity — `LatentETKF`/`LatentLETKF` match plain `ETKF` bit-for-bit at `atol=1e-12`
- [x] Round-trip identities — `LiftedObs(id) ≡ obs_op`, `EncodedDynamics(id, inner) ≡ inner`, `LatentDynamics(inner) ≡ inner.step`
- [x] L0 vmap correctness — `latent_ensemble`, `decode_ensemble`
- [x] Differentiability — `eqx.filter_grad` over a 2-window assimilation w.r.t. trainable codec weights, gradients finite + non-zero
- [x] JIT compatibility — `LatentETKF.assimilate` composes cleanly with `eqx.filter_jit`
- [x] Shape contract — non-square codec (`ℝ^4 → ℝ^2 → ℝ^4`) returns histories with the correct mixed `(T, Nₑ, Nₓ)` / `(T, Nₑ, N_z)` shapes
- [x] Protocol membership — `LiftedObs`, `LatentDynamics`, `EncodedDynamics` register as their abstract bases

Full repo: **219 passed in 250.82s** at 97.30% coverage. Lint, format, typecheck all green.

Closes #87.

https://claude.ai/code/session_01PPKxuHPad9k8wf3XsnKxvt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPKxuHPad9k8wf3XsnKxvt)_