### PR TITLE
docs: fix doctest-section rendering, convert docstring equations to MathJax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "pre-commit>=4.5.1",
+    # tests/test_docstrings.py parses docstrings the way mkdocstrings does.
+    "griffe>=1.0",
 ]
 lint = [
     "ruff>=0.15.10",

--- a/src/filterax/_diagnostics.py
+++ b/src/filterax/_diagnostics.py
@@ -44,7 +44,10 @@ def ensemble_spread(
 ) -> Float[Array, " N_x"]:
     r"""Per-variable ensemble standard deviation.
 
-    ``σᵢ = √( (Nₑ − 1)⁻¹ Σⱼ (xᵢ⁽ʲ⁾ − x̄ᵢ)² )``
+    $$
+    \sigma_i = \sqrt{(N_e - 1)^{-1}
+        \sum_{j} \big(x_i^{(j)} - \bar{x}_i\big)^2}
+    $$
 
     Track over assimilation cycles. A well-calibrated filter has
     ``σ ≈ RMSE``; collapsing spread is the first sign of filter
@@ -56,7 +59,7 @@ def ensemble_spread(
     Returns:
         Per-variable standard deviation of shape ``(Nₓ,)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax.utils import ensemble_spread
         >>> ens = jnp.array([[0.0, 0.0], [2.0, 4.0]])
@@ -74,7 +77,12 @@ def ensemble_spread(
 def rms_spread(
     ensemble: Float[Array, "N_e N_x"],
 ) -> Float[Array, ""]:
-    r"""Scalar RMS ensemble spread ``√(Nₓ⁻¹ Σᵢ σᵢ²)``."""
+    r"""Scalar RMS ensemble spread.
+
+    $$
+    \sqrt{N_x^{-1} \sum_i \sigma_i^2}
+    $$
+    """
     sigma = ensemble_spread(ensemble)
     return jnp.sqrt(jnp.mean(sigma * sigma))
 
@@ -83,13 +91,17 @@ def rmse_vs_truth(
     ensemble_mean_: Float[Array, " N_x"],
     x_true: Float[Array, " N_x"],
 ) -> Float[Array, ""]:
-    r"""RMSE of an ensemble mean against the true state ``√(Nₓ⁻¹ Σᵢ (x̄ᵢ − xᵢ*)²)``.
+    r"""RMSE of an ensemble mean against the true state.
+
+    $$
+    \mathrm{RMSE} = \sqrt{N_x^{-1} \sum_i \big(\bar{x}_i - x_i^*\big)^2}
+    $$
 
     Only available in twin / OSSE experiments where ``x_true`` is
     known. Track over time to detect filter divergence (RMSE growing
     without bound).
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax.utils import rmse_vs_truth
         >>> rmse_vs_truth(jnp.array([1.0, 2.0]), jnp.array([0.0, 2.0]))
@@ -112,7 +124,11 @@ def normalized_innovation(
     Hx_forecast: Float[Array, " N_y"],
     innovation_var: Float[Array, " N_y"],
 ) -> Float[Array, " N_y"]:
-    r"""Normalised innovation ``d_i / √(HPHᵀ + R)_{ii}``.
+    r"""Normalised innovation.
+
+    $$
+    d_i \big/ \sqrt{(H P H^{\top} + R)_{ii}}
+    $$
 
     For a correctly-specified filter the normalised innovation is
     ``𝒩(0, 1)`` componentwise. Departures from unit variance signal
@@ -126,8 +142,13 @@ def chi2_consistency(
     d: Float[Array, " N_y"],
     S_inv_d: Float[Array, " N_y"],
 ) -> Float[Array, ""]:
-    r"""``χ² = dᵀ S⁻¹ d``. Should be ``≈ Nᵧ`` under correct specification.
+    r"""Chi-squared innovation consistency statistic.
 
+    $$
+    \chi^2 = d^{\top} S^{-1} d
+    $$
+
+    Should be ``≈ Nᵧ`` under correct specification.
     Pre-compute ``S⁻¹ d`` once and pass it here so the diagnostic
     composes with whichever solver (gaussx Woodbury, dense Cholesky)
     you used for the analysis. Variance under the null is ``2 Nᵧ``.
@@ -152,7 +173,11 @@ def chi2_normalized(
 def effective_ensemble_size(
     weights: Float[Array, " N_e"],
 ) -> Float[Array, ""]:
-    r"""Effective sample size ``Nₑff = 1 / Σⱼ wⱼ²``.
+    r"""Effective sample size.
+
+    $$
+    N_{\mathrm{eff}} = 1 \Big/ \sum_{j} w_j^2
+    $$
 
     For equally-weighted ensembles (the standard EnKF) this is
     exactly ``Nₑ``. For particle filters / weighted EnKF variants,
@@ -168,7 +193,11 @@ def effective_ensemble_size(
 def weight_entropy(
     weights: Float[Array, " N_e"],
 ) -> Float[Array, ""]:
-    r"""Shannon entropy ``−Σⱼ wⱼ log wⱼ`` of importance weights.
+    r"""Shannon entropy of importance weights.
+
+    $$
+    -\sum_{j} w_j \log w_j
+    $$
 
     Maximum ``log Nₑ`` for uniform weights, ``0`` for full
     degeneracy.
@@ -188,7 +217,10 @@ def spread_skill_ratio(
 ) -> Float[Array, ""]:
     r"""Ratio of RMS spread to RMSE.
 
-    ``SSR = √(Σᵢ σᵢ² / Nₓ) / √(Σᵢ (x̄ᵢ − xᵢ*)² / Nₓ)``
+    $$
+    \mathrm{SSR} = \sqrt{\sum_i \sigma_i^2 / N_x} \Big/
+        \sqrt{\sum_i (\bar{x}_i - x_i^*)^2 / N_x}
+    $$
 
     * ``SSR ≈ 1`` — well calibrated.
     * ``SSR < 1`` — underdispersive (increase inflation).
@@ -224,7 +256,7 @@ def rank_histogram(
     Returns:
         ``(Nₑ + 1,)`` integer counts.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax.utils import rank_histogram
         >>> ens = jnp.array([[[0.0], [1.0]], [[0.0], [1.0]]])  # (T, N_e, N_x)
@@ -248,7 +280,11 @@ def rank_histogram(
 def rank_histogram_chi2(counts: Int[Array, " bins"]) -> Float[Array, ""]:
     r"""χ² flatness statistic for a rank histogram.
 
-    ``χ² = Σ_k (O_k − E_k)² / E_k`` with ``E_k = N_total / N_bins``.
+    $$
+    \chi^2 = \sum_k (O_k - E_k)^2 / E_k, \qquad
+    E_k = N_{\mathrm{total}} / N_{\mathrm{bins}}.
+    $$
+
     Larger values indicate stronger departure from uniformity; under
     the null hypothesis of uniformity the test statistic is
     ``χ²(N_bins − 1)``.
@@ -271,7 +307,11 @@ def desroziers_R_estimate(
 ) -> Float[Array, "N_y N_y"]:
     r"""A-posteriori estimate of ``R`` (Desroziers et al. 2005).
 
-    ``R̂ = E[ d_a d_fᵀ ]`` over time. When ``R̂`` disagrees with the
+    $$
+    \hat{R} = E\big[ d_a d_f^{\top} \big]
+    $$
+
+    estimated over time. When ``R̂`` disagrees with the
     prescribed ``R`` the observation-error covariance is mis-specified.
     Accumulate over many cycles (100+) for stable estimates.
     """
@@ -282,7 +322,12 @@ def desroziers_R_estimate(
 def desroziers_innovation_cov(
     d_forecast: Float[Array, "T N_y"],
 ) -> Float[Array, "N_y N_y"]:
-    r"""Empirical innovation covariance ``E[ d_f d_fᵀ ] ≈ HPHᵀ + R``."""
+    r"""Empirical innovation covariance.
+
+    $$
+    E\big[ d_f d_f^{\top} \big] \approx H P H^{\top} + R
+    $$
+    """
     T = d_forecast.shape[0]
     return einx.dot("t i, t j -> i j", d_forecast, d_forecast) / T
 
@@ -290,7 +335,12 @@ def desroziers_innovation_cov(
 def desroziers_analysis_residual_cov(
     d_analysis: Float[Array, "T N_y"],
 ) -> Float[Array, "N_y N_y"]:
-    r"""Empirical analysis-residual covariance ``E[ d_a d_aᵀ ] ≈ R − HAHᵀ``."""
+    r"""Empirical analysis-residual covariance.
+
+    $$
+    E\big[ d_a d_a^{\top} \big] \approx R - H A H^{\top}
+    $$
+    """
     T = d_analysis.shape[0]
     return einx.dot("t i, t j -> i j", d_analysis, d_analysis) / T
 
@@ -301,7 +351,11 @@ def dfs_from_gain(
 ) -> Float[Array, ""]:
     r"""Degrees of freedom for signal from an explicit gain.
 
-    ``DFS = tr(K H) ∈ [0, Nᵧ]``. Closer to ``Nᵧ`` means observations
+    $$
+    \mathrm{DFS} = \mathrm{tr}(K H) \in [0, N_y]
+    $$
+
+    Closer to ``Nᵧ`` means observations
     dominate the analysis; closer to ``0`` means the prior dominates.
 
     Reference:
@@ -318,7 +372,11 @@ def dfs_from_ensemble(
 ) -> Float[Array, ""]:
     r"""Ensemble-based DFS estimate from forecast / analysis perturbations.
 
-    ``DFS ≈ tr( Cᵃᶠ / σ_f² )`` where ``Cᵃᶠ`` is the per-variable
+    $$
+    \mathrm{DFS} \approx \mathrm{tr}\big( C^{af} / \sigma_f^2 \big)
+    $$
+
+    where ``Cᵃᶠ`` is the per-variable
     forecast-vs-analysis cross-covariance and ``σ_f²`` is the
     forecast variance — i.e. how much the analysis perturbations are
     *driven* by the forecast perturbations. ``DFS = Nₓ`` for an
@@ -352,11 +410,15 @@ def crps_ensemble(
 ) -> Float[Array, ""]:
     r"""Continuous Ranked Probability Score for a 1D ensemble forecast.
 
-    ``CRPS = E|X − y| − ½ E|X − X′|``
+    $$
+    \mathrm{CRPS} = E|X - y| - \tfrac{1}{2} E|X - X'|
+    $$
 
     Computed via the sorted-ensemble identity (Hersbach 2000):
 
-    ``½ E|X − X′| = Nₑ⁻² Σⱼ x_{(j)} (2j − 1 − Nₑ)``
+    $$
+    \tfrac{1}{2} E|X - X'| = N_e^{-2} \sum_{j} x_{(j)} (2j - 1 - N_e)
+    $$
 
     where ``x_{(j)}`` are the order statistics. Cost
     ``O(Nₑ log Nₑ)`` per observation. Lower is better; CRPS is a
@@ -370,7 +432,7 @@ def crps_ensemble(
     Returns:
         Scalar CRPS.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax.utils import crps_ensemble
         >>> crps_ensemble(jnp.array([0.0, 1.0]), jnp.array(0.5))

--- a/src/filterax/_filters/_models.py
+++ b/src/filterax/_filters/_models.py
@@ -150,7 +150,7 @@ class ETKF(eqx.Module, strict=True):
         config: Optional :class:`FilterConfig` reserved for future
             static configuration (ensemble size, diagnostics toggle, …).
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax import ETKF

--- a/src/filterax/_filters/_parametric.py
+++ b/src/filterax/_filters/_parametric.py
@@ -28,8 +28,12 @@ class SquareRootKF(eqx.Module, strict=True):
 
     Propagates a Gaussian belief through a linear-Gaussian model:
 
-    ``xₙ = Φ xₙ₋₁ + wₙ,  wₙ ~ 𝒩(0, Q)``
-    ``yₙ = H xₙ + vₙ,    vₙ ~ 𝒩(0, R)``
+    $$
+    \begin{aligned}
+    x_n &= \Phi x_{n-1} + w_n, & w_n &\sim \mathcal{N}(0, Q) \\
+    y_n &= H x_n + v_n, & v_n &\sim \mathcal{N}(0, R)
+    \end{aligned}
+    $$
 
     The forecast and analysis steps are both rewritten in *square-root*
     form on the Cholesky factor ``S`` of ``P`` so the covariance stays

--- a/src/filterax/_filters/_sequential.py
+++ b/src/filterax/_filters/_sequential.py
@@ -70,7 +70,13 @@ def _etkf_inner_spectrum(
 ) -> tuple[Float[Array, " N_y"], Float[Array, "K N_y"]]:
     r"""Rank-``Nᵧ`` spectrum of the inner product ``Y′ R⁻¹ Y′ᵀ``.
 
-    ``Y′ R⁻¹ Y′ᵀ = U_y diag(λ_i) U_yᵀ`` with ``U_y ∈ ℝ^{K × Nᵧ}`` an
+    The decomposition
+
+    $$
+    Y' R^{-1} Y'^{\top} = U_y \,\mathrm{diag}(\lambda_i)\, U_y^{\top}
+    $$
+
+    holds with ``U_y ∈ ℝ^{K × Nᵧ}`` an
     orthonormal basis for the column span of ``Y′`` (the only directions
     where the outer product has non-trivial action). The remaining
     ``K − Nᵧ`` eigenvalues are all zero; they correspond to a degenerate
@@ -120,7 +126,10 @@ def _apply_ctilde_func(
 ) -> Float[Array, "K ..."]:
     r"""Apply ``g(C̃)`` to ``v`` via the rank-``Nᵧ`` correction form.
 
-    ``g(C̃) = g_base · I + U_y diag(g_diff) U_yᵀ``
+    $$
+    g(\tilde{C}) = g_{\mathrm{base}} \cdot I
+        + U_y \,\mathrm{diag}(g_{\mathrm{diff}})\, U_y^{\top}
+    $$
 
     with ``g_diff[i] = g((Nₑ − 1) + λ_i) − g_base`` and
     ``g_base = g(Nₑ − 1)``. The caller supplies the precomputed
@@ -142,7 +151,10 @@ class StochasticEnKF(AbstractSequentialFilter, strict=True):
     Perturbed-observation update — each member sees an independent draw
     from the observation noise:
 
-    ``ε⁽ʲ⁾ ~ 𝒩(0, R),  x⁽ʲ⁾_a = x⁽ʲ⁾_f + K (y + ε⁽ʲ⁾ − H x⁽ʲ⁾_f)``
+    $$
+    \epsilon^{(j)} \sim \mathcal{N}(0, R), \qquad
+    x^{(j)}_a = x^{(j)}_f + K \big(y + \epsilon^{(j)} - H x^{(j)}_f\big)
+    $$
 
     Simple and robust; the perturbations introduce extra Monte Carlo
     variance whose magnitude scales as ``1/√Nₑ``.
@@ -159,7 +171,7 @@ class StochasticEnKF(AbstractSequentialFilter, strict=True):
         key: Default PRNG key used when no ``key`` is supplied in the
             ``analysis`` kwargs.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> import lineax as lx
@@ -236,12 +248,19 @@ class ETKF(AbstractSequentialFilter, strict=True):
     ``Nₑ``-dimensional ensemble subspace. Define the transform precision
     in the ensemble space and its symmetric inverse square root:
 
-    ``C̃ = (Nₑ − 1) I + Y′ R⁻¹ Y′ᵀ``
-    ``T = C̃⁻¹,  Wₐ = √((Nₑ − 1) T)``
+    $$
+    \tilde{C} = (N_e - 1) I + Y' R^{-1} Y'^{\top}, \qquad
+    T = \tilde{C}^{-1}, \qquad
+    W_a = \sqrt{(N_e - 1)\, T}
+    $$
 
     Mean and perturbation weights:
 
-    ``w̄ₐ = T Y′ R⁻¹ v,   X_a = x̄ 𝟙ᵀ + X′ᵀ (w̄ₐ 𝟙ᵀ + Wₐ)``
+    $$
+    \bar{w}_a = T\, Y' R^{-1} v, \qquad
+    X_a = \bar{x} \mathbf{1}^{\top}
+        + X'^{\top} \big(\bar{w}_a \mathbf{1}^{\top} + W_a\big)
+    $$
 
     The eigendecomposition is taken on the symmetrised ``C̃`` with a
     positive eigenvalue floor to keep the square root well-defined under
@@ -250,7 +269,7 @@ class ETKF(AbstractSequentialFilter, strict=True):
     Complexity ``O(Nₑ² Nᵧ + Nₑ³)`` per analysis — the inner solve is
     routed through gaussx so structured ``R`` does not densify.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax.filters import ETKF
@@ -339,7 +358,7 @@ class EnSRF(AbstractSequentialFilter, strict=True):
 
     Complexity matches ETKF: ``O(Nₑ² Nᵧ + Nₑ³)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax.filters import EnSRF
@@ -430,7 +449,7 @@ class LETKF(AbstractSequentialFilter, strict=True):
             ``(distances, radius) -> weights``. Defaults to
             :func:`filterax.gaspari_cohn`.
 
-    Example:
+    Examples:
         >>> import jax
         >>> import jax.numpy as jnp
         >>> import lineax as lx
@@ -571,7 +590,9 @@ def _mean_preserving_rotation(
     complement of ``𝟙``, draw a random rotation ``Q ∈ O(Nₑ−1)`` via
     the QR-of-Gaussian construction, and lift back to ``Nₑ`` space:
 
-    ``Θ = (1/Nₑ) 𝟙 𝟙ᵀ + V Q Vᵀ``
+    $$
+    \Theta = \tfrac{1}{N_e} \mathbf{1} \mathbf{1}^{\top} + V Q V^{\top}
+    $$
 
     By construction ``Θ 𝟙 = 𝟙`` (the constant vector is the +1
     eigenvector) and ``Θᵀ Θ = I`` (the orthogonal complement is
@@ -611,7 +632,10 @@ class ETKF_Livings(AbstractSequentialFilter, strict=True):
     al. break this symmetry by composing with a random orthogonal
     matrix:
 
-    ``W_a^{rot} = W_a · Θ,    Θ ∈ O(Nₑ),  Θ 𝟙 = 𝟙``
+    $$
+    W_a^{\mathrm{rot}} = W_a\, \Theta, \qquad
+    \Theta \in O(N_e), \quad \Theta \mathbf{1} = \mathbf{1}
+    $$
 
     The mean-preserving constraint ``Θ 𝟙 = 𝟙`` keeps the analysis
     mean and the rank-deficiency-against-𝟙 property; the random factor
@@ -690,13 +714,15 @@ class EnSRF_Serial(AbstractSequentialFilter, strict=True):
     Processes observations **one at a time** with the classical W&H
     scalar reduced-gain formula:
 
-    ``K_k = Cˣᴴₖ / (Cᴴₖᴴₖ + R_kk)``
-
-    ``x̄_a^{(k)} = x̄_a^{(k−1)} + K_k (y_k − H_k x̄_a^{(k−1)})``
-
-    ``α_k = 1 / (1 + √(R_kk / (Cᴴₖᴴₖ + R_kk)))``
-
-    ``X′_a^{(k)} = X′_a^{(k−1)} − α_k K_k (H_k X′_a^{(k−1)})``
+    $$
+    \begin{aligned}
+    K_k &= C^{x H_k} \big/ \big(C^{H_k H_k} + R_{kk}\big) \\
+    \bar{x}_a^{(k)} &= \bar{x}_a^{(k-1)}
+        + K_k \big(y_k - H_k \bar{x}_a^{(k-1)}\big) \\
+    \alpha_k &= 1 \Big/ \Big(1 + \sqrt{R_{kk} / (C^{H_k H_k} + R_{kk})}\Big) \\
+    X'^{(k)}_a &= X'^{(k-1)}_a - \alpha_k K_k \big(H_k X'^{(k-1)}_a\big)
+    \end{aligned}
+    $$
 
     No matrix inversion is required — each scalar update is an inner
     product. Cost ``O(Nₑ Nₓ Nᵧ)`` total. Requires **diagonal** ``R``
@@ -776,17 +802,29 @@ class ESTKF(AbstractSequentialFilter, strict=True):
 
     Reduced anomalies and transform precision:
 
-    ``X̃ = Lᵀ X′ ∈ ℝ^{(Nₑ−1) × Nₓ},   Ỹ = Lᵀ Y′ ∈ ℝ^{(Nₑ−1) × Nᵧ}``
+    $$
+    \tilde{X} = L^{\top} X' \in \mathbb{R}^{(N_e-1) \times N_x}, \qquad
+    \tilde{Y} = L^{\top} Y' \in \mathbb{R}^{(N_e-1) \times N_y}
+    $$
 
-    ``A = (Nₑ − 1) I + Ỹ R⁻¹ Ỹᵀ ∈ ℝ^{(Nₑ−1) × (Nₑ−1)}``
+    $$
+    A = (N_e - 1) I + \tilde{Y} R^{-1} \tilde{Y}^{\top}
+        \in \mathbb{R}^{(N_e-1) \times (N_e-1)}
+    $$
 
     Eigendecompose ``A = U Λ Uᵀ``:
 
-    ``w̃ = U Λ⁻¹ Uᵀ Ỹ R⁻¹ d,   W̃ = U √((Nₑ − 1) Λ⁻¹) Uᵀ``
+    $$
+    \tilde{w} = U \Lambda^{-1} U^{\top} \tilde{Y} R^{-1} d, \qquad
+    \tilde{W} = U \sqrt{(N_e - 1) \Lambda^{-1}}\, U^{\top}
+    $$
 
     Lift back to the full ensemble:
 
-    ``x̄_a = x̄_f + w̃ᵀ X̃,   X_a = x̄_a 𝟙ᵀ + L W̃ X̃``
+    $$
+    \bar{x}_a = \bar{x}_f + \tilde{w}^{\top} \tilde{X}, \qquad
+    X_a = \bar{x}_a \mathbf{1}^{\top} + L \tilde{W} \tilde{X}
+    $$
 
     Mean-preserving by construction; PSD analysis covariance;
     eigendecomposition is ``(Nₑ − 1)³`` rather than ``Nₑ³``.

--- a/src/filterax/_integrations/_pipekit.py
+++ b/src/filterax/_integrations/_pipekit.py
@@ -79,7 +79,7 @@ class FilterAnalysisStep(eqx.Module, strict=True):
             ``filter.analysis`` on every cycle — e.g. ``state_coords`` /
             ``obs_coords`` for :class:`filterax.filters.LETKF`.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax.filters import ETKF
@@ -132,7 +132,7 @@ class DynamicsForwardModel(eqx.Module, strict=True):
             ``(state, t0, t1) -> state`` callable).
         dt: Default integration step advertised to pipekit.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax.pipekit import DynamicsForwardModel
         >>> fwd = DynamicsForwardModel(lambda x, t0, t1: x + (t1 - t0), dt=0.5)
@@ -171,7 +171,7 @@ class LinearizableObsOperator(eqx.Module, strict=True):
         obs_op: A :class:`filterax.AbstractObsOperator` or plain
             ``state -> obs`` callable.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax.pipekit import LinearizableObsOperator
         >>> H = LinearizableObsOperator(lambda x: x[:1] ** 2)

--- a/src/filterax/_primitives/_gain.py
+++ b/src/filterax/_primitives/_gain.py
@@ -23,9 +23,15 @@ def kalman_gain(
     assembled as a :class:`gaussx.LowRankUpdate` so structural dispatch
     routes the solve through the Woodbury identity:
 
-    ``S⁻¹ = R⁻¹ − R⁻¹ U ((Nₑ − 1) I + Uᵀ R⁻¹ U)⁻¹ Uᵀ R⁻¹``
+    $$
+    S^{-1} = R^{-1} - R^{-1} U
+        \left( (N_{e} - 1) I + U^{\top} R^{-1} U \right)^{-1}
+        U^{\top} R^{-1},
+    \qquad
+    U = \frac{(HX)^{\prime\top}}{\sqrt{N_{e} - 1}}.
+    $$
 
-    with ``U = (HX)′ᵀ / √(Nₑ − 1)``. Total cost
+    Total cost
     ``O(Nₑ² Nᵧ + Nₑ³)`` for low-rank Woodbury, instead of ``O(Nᵧ³)`` for
     the dense fallback. The dense ``(Nᵧ, Nᵧ)`` matrix is never materialised
     when ``R`` carries structure (diagonal, low-rank, Toeplitz, …).
@@ -48,7 +54,7 @@ def kalman_gain(
     Raises:
         ValueError: if ``Nₑ < 2``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax import kalman_gain
@@ -74,10 +80,16 @@ def localized_kalman_gain(
     *,
     solver: gaussx.AbstractSolverStrategy | None = None,
 ) -> Float[Array, "N_x N_y"]:
-    r"""Localized Kalman gain ``K = (ρˣʸ ∘ Cˣᴴ) (ρʸʸ ∘ Cᴴᴴ + R)⁻¹``.
+    r"""Kalman gain with Schur-product (Hadamard) localization.
 
     Thin wrapper over :func:`gaussx.localized_kalman_gain` with the EnKF
-    Bessel convention. Tapering both covariances with the Schur
+    Bessel convention. Computes
+
+    $$
+    K = (\rho^{xy} \circ C^{xH})\,(\rho^{yy} \circ C^{HH} + R)^{-1}.
+    $$
+
+    Tapering both covariances with the Schur
     (element-wise) product suppresses spurious long-range correlations;
     by the Schur product theorem the tapered innovation covariance stays
     PSD when ``ρʸʸ`` is (use :func:`filterax.localization_matrix` /
@@ -103,7 +115,7 @@ def localized_kalman_gain(
     Raises:
         ValueError: if ``Nₑ < 2``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax import kalman_gain, localized_kalman_gain

--- a/src/filterax/_primitives/_inflation.py
+++ b/src/filterax/_primitives/_inflation.py
@@ -44,7 +44,7 @@ def inflate_multiplicative(
     Returns:
         Inflated ensemble of shape ``(Nₑ, Nₓ)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import inflate_multiplicative
         >>> ens = jnp.array([[0.0, 0.0], [2.0, 2.0]])
@@ -70,12 +70,19 @@ def inflate_rtps(
     Per-variable target spread is a convex blend of analysis and
     forecast standard deviations:
 
-    ``σ_target,i = (1 − α) σᵃ_i + α σᶠ_i``
+    $$
+    \sigma^{\text{target}}_{i} =
+        (1 - \alpha)\, \sigma^{a}_{i} + \alpha\, \sigma^{f}_{i}.
+    $$
 
     Each analysis anomaly is then rescaled so the resulting standard
-    deviation matches ``σ_target``:
+    deviation matches the target:
 
-    ``x⁽ʲ⁾_relaxed = x̄ᵃ + (σ_target,i / σᵃ_i) (x⁽ʲ⁾_a − x̄ᵃ)``
+    $$
+    x^{(j)}_{\text{relaxed}} = \bar{x}^{a}
+        + \frac{\sigma^{\text{target}}_{i}}{\sigma^{a}_{i}}
+          \left( x^{(j)}_{a} - \bar{x}^{a} \right).
+    $$
 
     Spatially adaptive (per-variable factor), mean-preserving, and
     parameterised by a single coefficient ``α``. ``α = 0`` is the
@@ -92,7 +99,7 @@ def inflate_rtps(
     Returns:
         Relaxed analysis ensemble of shape ``(Nₑ, Nₓ)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import inflate_rtps
         >>> forecast = jnp.array([[-2.0], [2.0]])
@@ -118,7 +125,10 @@ def inflate_rtpp(
 
     Convex combination of analysis and forecast anomaly matrices:
 
-    ``X′_relaxed = (1 − α) X′_a + α X′_f``
+    $$
+    X^{\prime}_{\text{relaxed}} =
+        (1 - \alpha)\, X^{\prime}_{a} + \alpha\, X^{\prime}_{f}.
+    $$
 
     Unlike RTPS (which acts on per-variable spread), RTPP operates on
     the full anomaly matrix and so blends inter-variable correlation
@@ -133,7 +143,7 @@ def inflate_rtpp(
     Returns:
         Relaxed analysis ensemble of shape ``(Nₑ, Nₓ)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import inflate_rtpp
         >>> forecast = jnp.array([[-2.0], [2.0]])
@@ -220,7 +230,12 @@ def inflate_adaptive(
     cycle's *normalised innovation*. The data-implied factor is the
     clamped Mahalanobis ratio
 
-    ``λ̂_obs = clip(dᵀ S⁻¹ d / Nᵧ,  min_factor,  max_factor)``
+    $$
+    \hat{\lambda}_{\text{obs}} = \operatorname{clip}\!\left(
+        \frac{d^{\top} S^{-1} d}{N_{y}},\
+        \lambda_{\min},\ \lambda_{\max}
+    \right)
+    $$
 
     (the simplified Anderson-2009 form — under correct specification
     ``E[χ²/Nᵧ] = 1``; under-dispersive ensembles overshoot and pull
@@ -229,9 +244,16 @@ def inflate_adaptive(
     ``λ̂_obs`` whose variance is the χ²-distribution variance
     ``σ²_obs = 2 / Nᵧ``:
 
-    ``μ_post = (σ²_λ · λ̂_obs + σ²_obs · μ_prior) / (σ²_λ + σ²_obs)``
-
-    ``σ²_post = σ²_λ · σ²_obs / (σ²_λ + σ²_obs)``
+    $$
+    \mu_{\text{post}} =
+        \frac{\sigma^{2}_{\lambda}\, \hat{\lambda}_{\text{obs}}
+              + \sigma^{2}_{\text{obs}}\, \mu_{\text{prior}}}
+             {\sigma^{2}_{\lambda} + \sigma^{2}_{\text{obs}}},
+    \qquad
+    \sigma^{2}_{\text{post}} =
+        \frac{\sigma^{2}_{\lambda}\, \sigma^{2}_{\text{obs}}}
+             {\sigma^{2}_{\lambda} + \sigma^{2}_{\text{obs}}}.
+    $$
 
     Returns the *posterior* ``(μ, σ²)`` as **JAX scalars** so callers
     can carry the belief through ``jax.jit`` / ``jax.grad`` / ``lax.scan``
@@ -285,19 +307,27 @@ def ledoit_wolf_shrinkage(
     Replaces the sample covariance with a convex combination toward a
     scalar-multiple-of-identity target:
 
-    ``P_shrunk = (1 − λ*) P_sample + λ* μ I``
+    $$
+    P_{\text{shrunk}} =
+        (1 - \lambda^{*})\, P_{\text{sample}} + \lambda^{*} \mu I,
+    $$
 
     where ``μ = tr(P_sample) / Nₓ`` is the average sample eigenvalue
     and ``λ* ∈ [0, 1]`` is the optimal shrinkage intensity that
-    minimises ``E ‖P_shrunk − P_true‖²_F``. The closed-form Ledoit-
-    Wolf estimator:
+    minimises ``E ‖P_shrunk − P_true‖²_F``. The closed-form
+    Ledoit-Wolf estimator:
 
-    ``λ* = min(1, b² / d²)``
+    $$
+    \lambda^{*} = \min\!\left( 1,\ \frac{b^{2}}{d^{2}} \right),
+    \qquad
+    d^{2} = \lVert P_{\text{sample}} - \mu I \rVert^{2}_{F},
+    \qquad
+    b^{2} = \frac{1}{N_{e}^{2}} \sum_{j}
+        \lVert x^{(j)} x^{(j)\top} - P_{\text{sample}} \rVert^{2}_{F},
+    $$
 
-    ``d² = ‖P_sample − μ I‖²_F``  (sample deviation from the target)
-
-    ``b² = (1 / Nₑ²) Σⱼ ‖x⁽ʲ⁾ x⁽ʲ⁾ᵀ − P_sample‖²_F`` (oracle
-    approximation; capped at ``d²`` so ``λ* ≤ 1``).
+    where ``d²`` is the sample deviation from the target and ``b²`` is
+    the oracle approximation, capped at ``d²`` so ``λ* ≤ 1``.
 
     Useful when ``Nₑ ≪ Nₓ`` and the rank-deficient sample covariance
     would otherwise contaminate downstream operations. **Positive

--- a/src/filterax/_primitives/_inflators.py
+++ b/src/filterax/_primitives/_inflators.py
@@ -31,15 +31,15 @@ from filterax._protocols import AbstractInflator
 
 
 class MultiplicativeInflator(AbstractInflator, strict=True):
-    r"""Multiplicative inflation :math:`X' \leftarrow \lambda X'`.
+    r"""Multiplicative inflation ``X′ ← λ X′``.
 
     Ignores ``forecast_particles`` and any extra kwargs.
 
     Attributes:
-        factor: Inflation factor :math:`\lambda > 0`; values in
+        factor: Inflation factor ``λ > 0``; values in
             ``[1.01, 1.10]`` are typical.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import MultiplicativeInflator
         >>> inflator = MultiplicativeInflator(factor=2.0)
@@ -70,7 +70,7 @@ class RTPS(AbstractInflator, strict=True):
         alpha: Relaxation coefficient in ``[0, 1]``. ``0`` keeps the
             analysis spread; ``1`` restores the forecast spread.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import RTPS
         >>> inflator = RTPS(alpha=1.0)
@@ -102,7 +102,7 @@ class RTPP(AbstractInflator, strict=True):
     Attributes:
         alpha: Relaxation coefficient in ``[0, 1]``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import RTPP
         >>> inflator = RTPP(alpha=0.5)
@@ -146,7 +146,7 @@ class AdditiveInflator(AbstractInflator, strict=True):
         base_key: PRNG key seed; folded against the per-call ``step``
             (or used as-is when no step / key is supplied).
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> import lineax as lx

--- a/src/filterax/_primitives/_likelihood.py
+++ b/src/filterax/_primitives/_likelihood.py
@@ -29,7 +29,11 @@ def log_likelihood(
 ) -> Float[Array, ""]:
     r"""Gaussian log-probability of an innovation vector.
 
-    ``log p(y | forecast) = −½ [Nᵧ log(2π) + log|S| + vᵀ S⁻¹ v]``
+    $$
+    \log p(y \mid \text{forecast}) = -\tfrac{1}{2} \left[
+        N_{y} \log(2\pi) + \log\lvert S \rvert + v^{\top} S^{-1} v
+    \right],
+    $$
 
     where ``v`` is the innovation and ``S`` the innovation covariance.
     Both ``log|S|`` and ``S⁻¹ v`` flow through :mod:`gaussx` dispatch —
@@ -52,7 +56,7 @@ def log_likelihood(
     Returns:
         Scalar log-probability.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax import log_likelihood
@@ -88,7 +92,7 @@ def innovation_covariance(
     Raises:
         ValueError: if ``Nₑ < 2``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax import innovation_covariance
@@ -154,7 +158,7 @@ def innovation_statistics(
     Raises:
         ValueError: if ``Nₑ < 2``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> from filterax import innovation_statistics

--- a/src/filterax/_primitives/_localization.py
+++ b/src/filterax/_primitives/_localization.py
@@ -10,7 +10,11 @@ Localization suppresses these artefacts by tapering covariance entries
 as a function of physical distance ``d``. The localized covariance is
 the Schur (Hadamard / element-wise) product
 
-``P_loc = ρ ∘ P,   ρᵢⱼ = ρ(dᵢⱼ / r)``
+$$
+P_{\text{loc}} = \rho \circ P,
+\qquad
+\rho_{ij} = \rho(d_{ij} / r),
+$$
 
 with ``r`` the localization half-width. By the Schur product theorem,
 ``ρ ∘ P`` is PSD whenever both factors are; the Gaspari-Cohn and
@@ -69,7 +73,7 @@ def localization_matrix(
     Returns:
         Taper matrix in ``[0, 1]`` of shape ``(N_a, N_b)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import localization_matrix
         >>> grid = jnp.arange(3.0)[:, None]  # three points on a line
@@ -86,12 +90,20 @@ def gaspari_cohn(
 ) -> Float[Array, "..."]:
     r"""Gaspari-Cohn 5th-order piecewise polynomial taper.
 
-    Define ``z = d / r``. Then
+    With ``z = d / r``:
 
-    ``ρ(z) = {  −¼ z⁵ + ½ z⁴ + ⅝ z³ − ⁵⁄₃ z² + 1,            0 ≤ z ≤ 1
-                 ⅟₁₂ z⁵ − ½ z⁴ + ⅝ z³ + ⁵⁄₃ z² − 5 z + 4 − ⅔ / z,
-                                                              1 < z ≤ 2
-                 0,                                            z > 2 }``
+    $$
+    \begin{aligned}
+    \rho(z) = \begin{cases}
+      -\tfrac14 z^5 + \tfrac12 z^4 + \tfrac58 z^3 - \tfrac53 z^2 + 1
+        & 0 \le z \le 1 \\
+      \tfrac1{12} z^5 - \tfrac12 z^4 + \tfrac58 z^3 + \tfrac53 z^2
+        - 5 z + 4 - \tfrac{2}{3 z}
+        & 1 < z \le 2 \\
+      0 & z > 2.
+    \end{cases}
+    \end{aligned}
+    $$
 
     Properties:
 
@@ -113,7 +125,7 @@ def gaspari_cohn(
     Returns:
         Taper weights in ``[0, 1]`` with the same shape as ``distances``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import gaspari_cohn
         >>> d = jnp.array([0.0, 1.0, 2.0, 3.0])
@@ -147,7 +159,7 @@ def gaussian_taper(
     Returns:
         Taper weights in ``(0, 1]`` with the same shape as ``distances``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import gaussian_taper
         >>> gaussian_taper(jnp.array([0.0, 1.0]), radius=1.0)
@@ -175,7 +187,7 @@ def hard_cutoff(
         Indicator weights (``0.0`` or ``1.0``) with the same shape as
         ``distances``, same dtype.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import hard_cutoff
         >>> hard_cutoff(jnp.array([0.5, 1.0, 1.5]), radius=1.0)
@@ -203,7 +215,7 @@ def localize(
     Returns:
         Localized matrix of shape ``(M, N)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import localize
         >>> cov = jnp.array([[1.0, 0.5], [0.5, 1.0]])
@@ -221,7 +233,9 @@ def soar_taper(
 ) -> Float[Array, "..."]:
     r"""Second-Order Auto-Regressive taper (Thiebaux & Pedder 1987).
 
-    ``ρ(d) = (1 + d/r) exp(−d/r)``
+    $$
+    \rho(d) = \left( 1 + \frac{d}{r} \right) e^{-d / r}.
+    $$
 
     Properties:
 
@@ -244,7 +258,7 @@ def soar_taper(
     Returns:
         Taper weights in ``(0, 1]`` with the same shape as ``distances``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import soar_taper
         >>> soar_taper(jnp.array([0.0, 1.0]), radius=1.0)
@@ -271,7 +285,9 @@ def adaptive_localization(
     ``r_{ij} = Cˣᴴ_{ij} / (σ_xᵢ σ_yⱼ)`` exceeds its sampling
     uncertainty:
 
-    ``se(r) ≈ (1 − r²) / √(Nₑ − 2)``
+    $$
+    \operatorname{se}(r) \approx \frac{1 - r^{2}}{\sqrt{N_{e} - 2}}.
+    $$
 
     Correlations smaller than ``significance · se(r)`` are zeroed.
     Correlations above that threshold are kept at unit weight (a
@@ -300,7 +316,7 @@ def adaptive_localization(
         ValueError: if ``Nₑ < 3`` (the ``√(Nₑ − 2)`` noise floor is
             undefined for the smallest ensembles).
 
-    Example:
+    Examples:
         >>> import jax
         >>> from filterax import adaptive_localization
         >>> state = jax.random.normal(jax.random.key(0), (20, 2))

--- a/src/filterax/_primitives/_perturbations.py
+++ b/src/filterax/_primitives/_perturbations.py
@@ -25,7 +25,13 @@ def perturbed_observations(
 ) -> Float[Array, "N_e N_y"]:
     r"""Generate perturbed observations for the stochastic EnKF.
 
-    ``y⁽ʲ⁾_pert = y + ε⁽ʲ⁾, ε⁽ʲ⁾ ~ 𝒩(0, R)`` for ``j = 1, …, Nₑ``.
+    $$
+    y^{(j)}_{\text{pert}} = y + \varepsilon^{(j)},
+    \qquad
+    \varepsilon^{(j)} \sim \mathcal{N}(0, R),
+    \qquad
+    j = 1, \dots, N_{e}.
+    $$
 
     The sampling path depends on the structure of ``R``:
 
@@ -47,7 +53,7 @@ def perturbed_observations(
     Returns:
         Perturbed observation matrix of shape ``(Nₑ, Nᵧ)``.
 
-    Example:
+    Examples:
         >>> import jax
         >>> import jax.numpy as jnp
         >>> import lineax as lx

--- a/src/filterax/_primitives/_statistics.py
+++ b/src/filterax/_primitives/_statistics.py
@@ -40,7 +40,7 @@ def ensemble_mean(
     Returns:
         Mean vector of shape ``(Nₓ,)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import ensemble_mean
         >>> ens = jnp.array([[0.0, 1.0], [2.0, 3.0]])
@@ -66,7 +66,7 @@ def ensemble_anomalies(
     Returns:
         Centred anomaly matrix of shape ``(Nₑ, Nₓ)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import ensemble_anomalies
         >>> ens = jnp.array([[0.0, 1.0], [2.0, 3.0]])
@@ -102,7 +102,7 @@ def ensemble_covariance(
     Raises:
         ValueError: if ``Nₑ < 2`` (the Bessel divisor is undefined).
 
-    Example:
+    Examples:
         >>> import gaussx
         >>> import jax.numpy as jnp
         >>> from filterax import ensemble_covariance
@@ -141,7 +141,7 @@ def cross_covariance(
     Raises:
         ValueError: if ``Nₑ < 2``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from filterax import cross_covariance
         >>> particles = jnp.array([[0.0, 0.0], [2.0, 2.0]])

--- a/src/filterax/_processes/_optax.py
+++ b/src/filterax/_processes/_optax.py
@@ -156,7 +156,7 @@ def eki(
         ensemble and returns the per-step mean delta as the optax
         update.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> import optax

--- a/src/filterax/_processes/_processes.py
+++ b/src/filterax/_processes/_processes.py
@@ -115,7 +115,11 @@ def _eki_delta(
     noise_cov: lx.AbstractLinearOperator,
     dt: Float[Array, ""],
 ) -> Float[Array, "J N_p"]:
-    r"""Per-member EKI increment ``δθ⁽ʲ⁾ = Δt Cᶿᴳ S⁻¹ (y − G⁽ʲ⁾)``.
+    r"""Per-member EKI increment.
+
+    $$
+    \delta\theta^{(j)} = \Delta t\, C^{\theta G} S^{-1} \big(y - G^{(j)}\big)
+    $$
 
     ``S`` is built as a low-rank update so the solve is Woodbury when
     ``Γ`` is structured. The cross-covariance ``Cᶿᴳ`` is a dense
@@ -147,7 +151,11 @@ class EKI(AbstractProcess, strict=True):
     Iterative ensemble method that drives ``θ⁽ʲ⁾`` toward a MAP /
     regularised-least-squares solution. The update for each member:
 
-    ``θ⁽ʲ⁾ₙ₊₁ = θ⁽ʲ⁾ₙ + Δtₙ Cᶿᴳₙ (Cᴳᴳₙ + Δtₙ⁻¹ Γ)⁻¹ (y − G(θ⁽ʲ⁾ₙ))``
+    $$
+    \theta^{(j)}_{n+1} = \theta^{(j)}_n + \Delta t_n\, C^{\theta G}_n
+        \big(C^{G G}_n + \Delta t_n^{-1} \Gamma\big)^{-1}
+        \big(y - G(\theta^{(j)}_n)\big)
+    $$
 
     The ensemble collapses to a point as ``algo_time → 1``: spread → 0,
     no posterior uncertainty (see :class:`EKS_Process` if you need
@@ -158,7 +166,7 @@ class EKI(AbstractProcess, strict=True):
             :class:`~filterax.DataMisfitController` for the standard
             adaptive recipe.
 
-    Example:
+    Examples:
         >>> import jax
         >>> import jax.numpy as jnp
         >>> import lineax as lx
@@ -236,8 +244,13 @@ class EKS_Process(AbstractProcess, strict=True):
     finite-sample mean correction and an ensemble-preconditioned
     Brownian noise:
 
-    ``dθ⁽ʲ⁾ = Cᶿᴳ Γ⁻¹ (y − G⁽ʲ⁾) dt − (Nₚ + 1) J⁻¹ (θ⁽ʲ⁾ − θ̄) dt
-                + √(2 Cᶿᶿ) dW⁽ʲ⁾``
+    $$
+    \mathrm{d}\theta^{(j)} =
+        C^{\theta G} \Gamma^{-1} \big(y - G^{(j)}\big)\, \mathrm{d}t
+        - (N_p + 1)\, J^{-1} \big(\theta^{(j)} - \bar{\theta}\big)\,
+          \mathrm{d}t
+        + \sqrt{2\, C^{\theta\theta}}\; \mathrm{d}W^{(j)}
+    $$
 
     The discrete-time recipe used here matches Garbuno-Inigo §4: an
     EKI-style mean update (with ``Δt⁻¹ Γ`` tempering), the
@@ -350,14 +363,26 @@ def sigma_points(
 
     For mean ``μ`` and covariance ``Σ``:
 
-    ``λ = α² (Nₚ + κ) − Nₚ,   c = √(Nₚ + λ)``
+    $$
+    \lambda = \alpha^2 (N_p + \kappa) - N_p, \qquad
+    c = \sqrt{N_p + \lambda}
+    $$
 
-    ``χ⁰ = μ,   χ⁺ⱼ = μ + c · [√Σ]_{:,j},   χ⁻ⱼ = μ − c · [√Σ]_{:,j}``
+    $$
+    \chi^0 = \mu, \qquad
+    \chi^{+}_j = \mu + c \, [\sqrt{\Sigma}]_{:,j}, \qquad
+    \chi^{-}_j = \mu - c \, [\sqrt{\Sigma}]_{:,j}
+    $$
 
     with weights for the mean and covariance:
 
-    ``Wₘ⁰ = λ/(Nₚ+λ),  Wc⁰ = Wₘ⁰ + (1 − α² + β)``
-    ``Wₘⁱ = Wcⁱ = 1/(2(Nₚ+λ)) for i ≠ 0``
+    $$
+    \begin{aligned}
+    W_m^0 &= \frac{\lambda}{N_p + \lambda}, &
+    W_c^0 &= W_m^0 + (1 - \alpha^2 + \beta), \\
+    W_m^i &= W_c^i = \frac{1}{2 (N_p + \lambda)} & &\text{for } i \neq 0.
+    \end{aligned}
+    $$
 
     ``√Σ`` comes from :func:`gaussx.root_decomposition` so structured
     ``Σ`` (diagonal, low-rank, …) skips the dense Cholesky.
@@ -398,8 +423,14 @@ class UKI(AbstractProcess, strict=True):
     generates ``2 Nₚ + 1`` sigma points, evaluates the forward model on
     them, and applies a Kalman update on the unscented statistics:
 
-    ``μₙ₊₁ = μₙ + Δt Cᶿʸ Sₙ⁻¹ (y − ŷ₀)``
-    ``Σₙ₊₁ = Σₙ − Δt Cᶿʸ Sₙ⁻¹ Cᶿʸ ᵀ``
+    $$
+    \begin{aligned}
+    \mu_{n+1} &= \mu_n
+        + \Delta t\, C^{\theta y} S_n^{-1} \big(y - \hat{y}_0\big) \\
+    \Sigma_{n+1} &= \Sigma_n
+        - \Delta t\, C^{\theta y} S_n^{-1} C^{\theta y \top}
+    \end{aligned}
+    $$
 
     Deterministic (no sampling noise), no ensemble collapse, and the
     covariance ``Σₙ`` gives a calibrated posterior in the linear-Gaussian
@@ -664,9 +695,14 @@ class GNKI(AbstractProcess, strict=True):
     (``J̃ ≈ Cᶿᴳ (Cᶿᶿ)⁻¹``) and applies a Gauss-Newton update with prior
     pull-back:
 
-    ``δθ⁽ʲ⁾ = K (y − G⁽ʲ⁾) + (I − K J̃)(m₀ − θ⁽ʲ⁾)``
+    $$
+    \delta\theta^{(j)} = K \big(y - G^{(j)}\big)
+        + \big(I - K \tilde{J}\big)\big(m_0 - \theta^{(j)}\big), \qquad
+    K = \big(\tilde{J}^{\top} \Gamma^{-1} \tilde{J}
+        + \Sigma_0^{-1}\big)^{-1} \tilde{J}^{\top} \Gamma^{-1}.
+    $$
 
-    with ``K = (J̃ ᵀ Γ⁻¹ J̃ + Σ₀⁻¹)⁻¹ J̃ ᵀ Γ⁻¹``. Faster convergence
+    Faster convergence
     than :class:`EKI` for well-conditioned problems and requires
     ``J > Nₚ`` so ``Cᶿᶿ`` is invertible. In the linear-Gaussian limit
     GNKI recovers the exact posterior mean *and* covariance.
@@ -767,7 +803,10 @@ class SparseInversion(AbstractProcess, strict=True):
 
     Standard EKI step followed by an L¹ proximal soft-threshold:
 
-    ``prox_{λ‖·‖₁}(z)ᵢ = sign(zᵢ) · max(|zᵢ| − λ, 0)``
+    $$
+    \mathrm{prox}_{\lambda \|\cdot\|_1}(z)_i =
+        \mathrm{sign}(z_i) \cdot \max\big(|z_i| - \lambda,\, 0\big)
+    $$
 
     drives inactive parameters exactly to zero. Useful for variable
     selection / sparse physics discovery / sensor placement.
@@ -829,7 +868,11 @@ class TEKI(AbstractProcess, strict=True):
     Standard EKI on an augmented system that includes the parameters in
     observation space:
 
-    ``G̃(θ) = (G(θ), θ)ᵀ,   ỹ = (y, m₀)ᵀ,   Γ̃ = blockdiag(Γ, Σ₀)``
+    $$
+    \tilde{G}(\theta) = \big(G(\theta),\, \theta\big)^{\top}, \qquad
+    \tilde{y} = (y,\, m_0)^{\top}, \qquad
+    \tilde{\Gamma} = \mathrm{blockdiag}(\Gamma,\, \Sigma_0)
+    $$
 
     The augmented identity block in ``Cᶿᴳ̃`` pulls particles toward the
     prior mean ``m₀`` and prevents the ensemble from drifting arbitrarily

--- a/src/filterax/_processes/_schedulers.py
+++ b/src/filterax/_processes/_schedulers.py
@@ -36,7 +36,7 @@ class FixedScheduler(AbstractScheduler, strict=True):
     Attributes:
         dt: Positive scalar step size.
 
-    Example:
+    Examples:
         >>> from filterax import FixedScheduler
         >>> sched = FixedScheduler(dt=0.5)
         >>> float(sched.get_dt(state=None))  # constant, ignores the state
@@ -57,11 +57,16 @@ class DataMisfitController(AbstractScheduler, strict=True):
     a uniform fraction of the total artificial-time interval ``[0, 1]``.
     The recipe:
 
-    ``Δtₙ = min(target_misfit / Φₙ, 1 − algo_timeₙ)``
+    $$
+    \Delta t_n = \min\big(\text{target\_misfit} / \Phi_n,\;
+        1 - \text{algo\_time}_n\big)
+    $$
 
     with the per-step misfit norm
 
-    ``Φₙ = J⁻¹ Σⱼ ‖y − G(θ⁽ʲ⁾)‖²_{Γ⁻¹}``
+    $$
+    \Phi_n = J^{-1} \sum_{j} \big\| y - G(\theta^{(j)}) \big\|^2_{\Gamma^{-1}}
+    $$
 
     computed in observation space — ``state.noise_cov`` carries ``Γ``
     itself, and we apply ``Γ⁻¹`` internally via :func:`gaussx.solve_rows`
@@ -105,7 +110,10 @@ class EKSStableScheduler(AbstractScheduler, strict=True):
     ``Cᶿᶿ`` (Garbuno-Inigo et al. 2020 §5). We clip ``Δt`` so the
     drift term is bounded:
 
-    ``Δtₙ = min(max_dt, target / ‖Cᶿᶿₙ‖₂)``
+    $$
+    \Delta t_n = \min\big(\text{max\_dt},\;
+        \text{target} / \|C^{\theta\theta}_n\|_2\big)
+    $$
 
     We bound the spectral norm via the Frobenius norm of the
     ``Nₑ × Nₑ`` Gram of the anomalies — ``‖A‖₂ ≤ ‖A‖_F`` for any

--- a/src/filterax/_smoothers.py
+++ b/src/filterax/_smoothers.py
@@ -64,10 +64,16 @@ def _smoother_step(
     r"""One backward smoother step.
 
     Applies the per-member update
-    ``X^s_t[j] = X^a_t[j] + G_t (X^s_{t+1}[j] - X^f_{t+1}[j])`` using the
-    ensemble-space factorisation
 
-    ``G_t (X^s_{t+1} - X^f_{t+1}) = D Fᵀ (F Fᵀ)⁺ A``
+    $$
+    X^s_t[j] = X^a_t[j] + G_t \big(X^s_{t+1}[j] - X^f_{t+1}[j]\big)
+    $$
+
+    using the ensemble-space factorisation
+
+    $$
+    G_t \big(X^s_{t+1} - X^f_{t+1}\big) = D F^{\top} (F F^{\top})^{+} A
+    $$
 
     where ``A = X^a_t − x̄^a_t``, ``F = X^f_{t+1} − x̄^f_{t+1}``, and
     ``D = X^s_{t+1} − X^f_{t+1}`` are arranged with rows as members. The
@@ -162,7 +168,10 @@ class EnKS(eqx.Module, strict=True):
     smoother gain at step ``t`` is the sample cross-covariance times the
     pseudoinverse of the sample forecast covariance,
 
-    ``G_t = (Nₑ − 1)⁻¹ A_tᵀ F_{t+1} · ((Nₑ − 1)⁻¹ F_{t+1}ᵀ F_{t+1})⁺``,
+    $$
+    G_t = (N_e - 1)^{-1} A_t^{\top} F_{t+1}
+        \cdot \big((N_e - 1)^{-1} F_{t+1}^{\top} F_{t+1}\big)^{+},
+    $$
 
     factored through the ``Nₑ × Nₑ`` Gram matrix ``F Fᵀ`` so the dense
     ``Nₓ × Nₓ`` forecast covariance is never materialised.
@@ -174,7 +183,7 @@ class EnKS(eqx.Module, strict=True):
 
     Complexity: ``O(T (Nₑ² Nₓ + Nₑ³))`` for the whole backward pass.
 
-    Example:
+    Examples:
         >>> import jax
         >>> from filterax import EnKS
         >>> k1, k2 = jax.random.split(jax.random.key(0))
@@ -324,12 +333,22 @@ def _sqrt_smoother_step(
 
     Decomposes the update into:
 
-    * **Mean** — ``m^s_t = m^a_t + G_t (m^s_{t+1} - m^f_{t+1})`` via the
-      dual ensemble form ``G_t v = A_tᵀ (F Fᵀ)⁺ F v``.
-    * **Perturbations** — apply a symmetric square-root transform in
-      ensemble space ``W = Λ^{1/2}`` with
-      ``Λ = I + K_e (Dᵀ D − Fᵀ F) K_eᵀ`` and
-      ``K_e = (F Fᵀ)⁺ F``. New anomalies = ``Wᵀ A_t``.
+    * **Mean** — via the dual ensemble form:
+
+      $$
+      m^s_t = m^a_t + G_t \big(m^s_{t+1} - m^f_{t+1}\big), \qquad
+      G_t v = A_t^{\top} (F F^{\top})^{+} F v
+      $$
+
+    * **Perturbations** — apply a symmetric square-root transform
+      ``W = Λ^{1/2}`` in ensemble space, with
+
+      $$
+      \Lambda = I + K_e \big(D^{\top} D - F^{\top} F\big) K_e^{\top},
+      \qquad K_e = (F F^{\top})^{+} F.
+      $$
+
+      New anomalies = ``Wᵀ A_t``.
 
     Negative eigenvalues of ``Λ`` (sample-noise artefacts when the
     smoother reduces variance) are clamped to zero before the sqrt.
@@ -414,7 +433,10 @@ class EnsembleSqrtSmoother(eqx.Module, strict=True):
     perturbation half applied through a *symmetric square root* of the
     ensemble-space cov-update transform
 
-    ``Λ = I + K_e (Dᵀ D − Fᵀ F) K_eᵀ,    K_e = (F Fᵀ)⁺ F``.
+    $$
+    \Lambda = I + K_e \big(D^{\top} D - F^{\top} F\big) K_e^{\top}, \qquad
+    K_e = (F F^{\top})^{+} F.
+    $$
 
     This avoids accumulating cross-member coupling across many backward
     steps — the same reason :class:`ETKF` uses a symmetric square-root
@@ -455,7 +477,10 @@ def _ies_step(
 ) -> Float[Array, "J N_p"]:
     r"""One Chen-Oliver IES iteration.
 
-    ``θ_{i+1}^j = (1 − α) θ_i^j + α [θ_0^j + K_i (y + ε^j − G(θ_i^j))]``
+    $$
+    \theta_{i+1}^j = (1 - \alpha)\, \theta_i^j + \alpha \big[\theta_0^j
+        + K_i \big(y + \epsilon^j - G(\theta_i^j)\big)\big]
+    $$
 
     where ``K_i = C^{θG}_i (C^{GG}_i + Γ_y)⁻¹`` is the sample-cov gain
     at the current iterate. With ``α = 1`` this is the pure
@@ -489,7 +514,10 @@ class IES(eqx.Module, strict=True):
     Standalone iterative ensemble method that solves an inverse problem
     in a single window of observations. At each iteration:
 
-    ``θ_{i+1}^j = (1 − α) θ_i^j + α [θ_0^j + K_i (y + ε^j − G(θ_i^j))]``
+    $$
+    \theta_{i+1}^j = (1 - \alpha)\, \theta_i^j + \alpha \big[\theta_0^j
+        + K_i \big(y + \epsilon^j - G(\theta_i^j)\big)\big]
+    $$
 
     The anchor to ``θ_0^j`` (the *initial* ensemble member) is what
     distinguishes IES from :class:`~filterax.EKI`'s drift-style

--- a/src/filterax/_train/_differentiable.py
+++ b/src/filterax/_train/_differentiable.py
@@ -138,7 +138,7 @@ def differentiable_assimilate(
         ``L2.assimilate(...)``. ``log_likelihoods`` is always populated
         because every deterministic filter returns one.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import lineax as lx
         >>> import filterax as flx

--- a/src/filterax/_train/_road.py
+++ b/src/filterax/_train/_road.py
@@ -1,4 +1,4 @@
-"""ROAD-EnKF — reduced-order autodifferentiable EnKF (Wave 5.B+).
+r"""ROAD-EnKF — reduced-order autodifferentiable EnKF (Wave 5.B+).
 
 Memory-efficient gradient strategy for training through the filter on
 long observation horizons. Where :func:`differentiable_assimilate` keeps
@@ -10,7 +10,11 @@ ROAD-EnKF takes the **local-gradient** approach:
    *with* gradient enabled, getting a local gradient
    ``∇_θ L_t``.
 2. Sum the local gradients across all steps:
-   ``∇_θ L ≈ Σ_t ∇_θ L_t``.
+
+   $$
+   \nabla_\theta L \approx \sum_t \nabla_\theta L_t.
+   $$
+
 3. Advance the ensemble between steps with :func:`jax.lax.stop_gradient`
    so no autodiff tape spans more than one filter cycle.
 

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,95 @@
+"""Docstring quality gates for the rendered API docs.
+
+mkdocstrings renders docstrings through griffe's Google-style parser,
+and two classes of mistake silently degrade the built docs:
+
+* Doctest code under a header griffe does not recognise as an examples
+  section (e.g. singular ``Example:``) is parsed as a generic
+  admonition, and the ``>>>`` lines collapse into a run-together
+  paragraph instead of a highlighted code block.
+* Unbalanced ``$$`` math fences leave raw TeX in the rendered page.
+
+These tests parse every docstring in the package exactly the way the
+docs build does and fail on either mistake, so the problems cannot
+reach the published site again.
+"""
+
+from __future__ import annotations
+
+import griffe
+import pytest
+from griffe import Docstring, DocstringSectionKind, Parser
+
+
+def _iter_docstrings(obj, seen):
+    """Yield (path, Docstring) for every object defined in filterax."""
+    if obj.path in seen:
+        return
+    seen.add(obj.path)
+    if obj.docstring is not None:
+        yield obj.path, obj.docstring
+    members = getattr(obj, "members", {})
+    for member in members.values():
+        # Skip aliases (re-exports): gaussx-owned docstrings are tested
+        # upstream, and filterax-owned ones are reached at their
+        # definition site.
+        if member.is_alias:
+            continue
+        yield from _iter_docstrings(member, seen)
+
+
+@pytest.fixture(scope="module")
+def all_docstrings() -> list[tuple[str, Docstring]]:
+    pkg = griffe.load("filterax", search_paths=["src"])
+    docstrings = list(_iter_docstrings(pkg, set()))
+    assert len(docstrings) > 50  # the walk found the real package
+    return docstrings
+
+
+def test_doctests_parse_as_examples_sections(all_docstrings):
+    """Every ``>>>`` snippet must land in a real examples section.
+
+    A doctest inside a text or admonition section means the section
+    header is one griffe does not recognise (the ``Example:`` vs
+    ``Examples:`` trap) and the code will render as prose.
+    """
+    offenders = []
+    for path, docstring in all_docstrings:
+        for section in docstring.parse(Parser.google):
+            if section.kind is DocstringSectionKind.examples:
+                continue
+            if section.kind is DocstringSectionKind.admonition:
+                text = section.value.contents
+            elif section.kind is DocstringSectionKind.text:
+                text = section.value
+            else:
+                continue
+            if ">>>" in str(text):
+                offenders.append(f"{path} ({section.kind.value})")
+    assert not offenders, (
+        "Doctest code outside an examples section — use the plural "
+        f"'Examples:' header so mkdocstrings renders it as code: {offenders}"
+    )
+
+
+def test_examples_sections_contain_code(all_docstrings):
+    """Parsed examples sections must carry at least one code part."""
+    offenders = []
+    for path, docstring in all_docstrings:
+        for section in docstring.parse(Parser.google):
+            if section.kind is not DocstringSectionKind.examples:
+                continue
+            kinds = [kind for kind, _ in section.value]
+            if DocstringSectionKind.examples not in kinds:
+                offenders.append(path)
+    assert not offenders, f"Examples sections without doctest code: {offenders}"
+
+
+def test_math_fences_are_balanced(all_docstrings):
+    """``$$`` math fences must come in pairs, or raw TeX leaks into the docs."""
+    offenders = [
+        path
+        for path, docstring in all_docstrings
+        if docstring.value.count("$$") % 2 != 0
+    ]
+    assert not offenders, f"Unbalanced $$ math fences: {offenders}"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "filterax"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },

--- a/uv.lock
+++ b/uv.lock
@@ -563,6 +563,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "griffe" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -600,6 +601,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "griffe", specifier = ">=1.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -692,6 +694,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffecli" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/49/eb6d2935e27883af92c930ed40cc4c69bcd32c402be43b8ca4ab20510f67/griffe-2.0.2.tar.gz", hash = "sha256:c5d56326d159f274492e9bf93a9895cec101155d944caa66d0fc4e0c13751b92", size = 293757, upload-time = "2026-03-27T11:34:52.205Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/c0/2bb018eecf9a83c68db9cd9fffd9dab25f102ad30ed869451046e46d1187/griffe-2.0.2-py3-none-any.whl", hash = "sha256:2b31816460aee1996af26050a1fc6927a2e5936486856707f55508e4c9b5960b", size = 5141, upload-time = "2026-03-27T11:34:47.721Z" },
+]
+
+[[package]]
+name = "griffecli"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/e0/6a7d661d71bb043656a109b91d84a42b5342752542074ec83b16a6eb97f0/griffecli-2.0.2.tar.gz", hash = "sha256:40a1ad4181fc39685d025e119ae2c5b669acdc1f19b705fb9bf971f4e6f6dffb", size = 56281, upload-time = "2026-03-27T11:34:50.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e8/90d93356c88ac34c20cb5edffca68138df55ca9bbd1a06eccfbcec8fdbe5/griffecli-2.0.2-py3-none-any.whl", hash = "sha256:0d44d39e59afa81e288a3e1c3bf352cc4fa537483326ac06b8bb6a51fd8303a0", size = 9500, upload-time = "2026-03-27T11:34:48.81Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes two rendering bugs in the API docs and adds regression tests so they can't come back.

### Examples rendered as run-together prose
Doctest sections were titled `Example:` (singular). griffe's Google parser only recognises the plural `Examples:` as a doctest section — the singular form falls through to a generic admonition, and the `>>>` lines collapse into a single paragraph of prose (the mush visible on the published API pages). All 41 headers renamed to `Examples:`; verified in the built HTML that they now render as highlighted code blocks.

### Equations not MkDocs-compatible
Display equations were unicode pseudo-math inside literal code spans (e.g. ``C̃ = (Nₑ−1)I + Y′ᵀR⁻¹Y′``), which renders as plain text. Converted **65 display equations across 14 modules** to `$$ … $$` LaTeX blocks rendered by `pymdownx.arithmatex` + MathJax (the gaussx house style): Gaspari-Cohn piecewise, RTPS/RTPP/adaptive inflation, Ledoit-Wolf, Woodbury, ETKF/EnSRF/ESTKF transforms, smoother recursions, EKI/EKS/UKI updates, sigma-point weights, schedulers, and all the diagnostics formulas. Equation-heavy summary lines were reworded to prose with the math moved into the body, and two broken Sphinx `:math:` roles were replaced. Unicode math in `#` code comments is untouched (explicitly allowed).

### Regression tests (`tests/test_docstrings.py`)
Parses every docstring in the package exactly the way the docs build does (griffe, Google parser) and fails on:
- a `>>>` snippet landing outside a real examples section (catches the `Example:` vs `Examples:` trap — this test fails on the pre-fix tree),
- an examples section that parses without a code part,
- unbalanced `$$` math fences (raw TeX leaking into pages).

## Test plan
- [x] `uv run pytest` — 241 passed, 1 skipped (incl. the 3 new docstring gates)
- [x] `pytest --doctest-modules src/filterax` — 41 doctests passed
- [x] `ruff check .` / `ruff format --check .` / `ty check src/filterax` — clean
- [x] `mkdocs build` — clean; built HTML inspected: `kalman_gain` Examples render as code blocks (prose regression gone), math renders as `arithmatex` MathJax divs (e.g. 16 on the diagnostics page)

https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd

---
_Generated by [Claude Code](https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd)_