### PR TITLE
docs: mathematical reference — 16 chapters, notation, references

### DIFF
--- a/docs/math/01_problem_setting.md
+++ b/docs/math/01_problem_setting.md
@@ -1,0 +1,227 @@
+# Problem Setting
+
+Sequential data assimilation is the problem of tracking the state of a
+dynamical system through time, given a stream of partial, noisy
+observations and a model of the dynamics. Unlike the batch (variational)
+formulation, the sequential problem never looks at all the data at once:
+each new observation updates the current belief about the state, and that
+updated belief is propagated forward to meet the next observation. The
+ensemble Kalman filter family — the subject of these chapters — is a
+Monte Carlo solution to this problem that scales to state dimensions
+where exact Bayesian filtering is hopeless.
+
+## The state-space model
+
+Let $x_t \in \mathbb{R}^{N_x}$ denote the state at time $t$ and
+$y_t \in \mathbb{R}^{N_y}$ the observations. Two equations define the
+problem:
+
+$$
+x_t = \mathcal{M}(x_{t-1}) + \eta_t, \qquad \eta_t \sim \mathcal{N}(0, Q),
+$$
+
+$$
+y_t = \mathcal{H}(x_t) + \varepsilon_t, \qquad \varepsilon_t \sim \mathcal{N}(0, R).
+$$
+
+The dynamics $\mathcal{M}$ may be a discretised PDE, an ODE integrator,
+or a learned emulator; the observation operator $\mathcal{H}$ maps the
+state into observation space (chapter 3). Model error $\eta_t$ and
+observation error $\varepsilon_t$ are assumed independent of each other
+and across time.
+
+## The Bayes filter
+
+The exact solution alternates two steps. Given the posterior (the
+*analysis*) at time $t-1$, the **forecast step** pushes it through the
+dynamics via the Chapman–Kolmogorov equation:
+
+$$
+p(x_t \mid y_{1:t-1}) = \int p(x_t \mid x_{t-1})\, p(x_{t-1} \mid y_{1:t-1})\, \mathrm{d}x_{t-1}.
+$$
+
+The **analysis step** conditions on the new observation via Bayes'
+theorem:
+
+$$
+p(x_t \mid y_{1:t}) \propto p(y_t \mid x_t)\, p(x_t \mid y_{1:t-1}).
+$$
+
+This recursion is exact but intractable in general: the densities live
+in $\mathbb{R}^{N_x}$, and for a weather or ocean model $N_x$ is
+$10^6$–$10^9$. Every practical filter is an approximation to this
+recursion; the approximations differ in what they keep.
+
+## The Gaussian approximation
+
+If the dynamics and observation operator are linear and all errors are
+Gaussian, both steps preserve Gaussianity and the recursion closes on a
+mean and covariance — the classical Kalman filter (Kalman 1960). Writing
+the forecast (prior) moments as $x^f, P^f$ and the analysis (posterior)
+moments as $x^a, P^a$:
+
+$$
+\begin{aligned}
+\text{forecast:} &\quad x^f_t = M\, x^a_{t-1}, \qquad P^f_t = M P^a_{t-1} M^\top + Q, \\
+\text{analysis:} &\quad x^a_t = x^f_t + K_t\, d_t, \qquad P^a_t = (I - K_t H)\, P^f_t,
+\end{aligned}
+$$
+
+with innovation $d_t = y_t - H x^f_t$ and Kalman gain
+$K_t = P^f_t H^\top (H P^f_t H^\top + R)^{-1}$ (derived in chapter 4).
+
+Two things break at scale. Storing and propagating $P \in
+\mathbb{R}^{N_x \times N_x}$ costs $O(N_x^2)$ memory and $O(N_x^3)$
+work — out of the question for large $N_x$. And the covariance
+propagation $M P M^\top$ requires the tangent-linear model $M$ and its
+adjoint, which for a complex nonlinear $\mathcal{M}$ may not exist in
+code at all.
+
+## Why ensembles
+
+The ensemble Kalman filter (Evensen 1994) replaces the explicit
+$(x, P)$ pair with $N_e$ samples — an ensemble matrix
+$X \in \mathbb{R}^{N_e \times N_x}$ whose rows are state vectors.
+The forecast step becomes embarrassingly simple: propagate each member
+through the *full nonlinear* model,
+
+$$
+x^{f,(j)}_t = \mathcal{M}\big(x^{a,(j)}_{t-1}\big) + \eta^{(j)}_t,
+\qquad j = 1, \dots, N_e,
+$$
+
+and the forecast mean and covariance are estimated as sample moments of
+the propagated ensemble (chapter 2). This sidesteps both failures at
+once:
+
+- **Second moments by Monte Carlo.** The covariance is never stored;
+  it is implicit in $N_e$ state vectors, at $O(N_e N_x)$ memory. With
+  $N_e \sim 20$–$100$, this is a few model states, not a matrix.
+- **No tangent-linear model.** The nonlinear $\mathcal{M}$ is used
+  as-is, $N_e$ times. No adjoint, no linearisation, no extra code. The
+  same trick handles nonlinear $\mathcal{H}$ in the analysis step
+  (chapter 3).
+
+The price is sampling error: all second moments are estimated from
+$N_e$ samples, with errors of order $1/\sqrt{N_e}$, and the sample
+covariance has rank at most $N_e - 1$. Chapter 2 makes this precise.
+
+## The forecast–analysis cycle
+
+Operationally, the filter is a loop:
+
+```
+X ← initial ensemble                      # (N_e, N_x)
+for each observation window t:
+    X ← M applied to each row of X        # forecast (caller's model)
+    X ← analysis(X, y_t, H, R)            # Bayes update (filterax)
+```
+
+The analysis step is where the ensemble Kalman filters differ:
+the stochastic EnKF perturbs the observations (chapter 5), the
+deterministic square-root filters (ETKF, EnSRF — chapters 6–7) transform
+the anomalies exactly. All of them consume the same inputs — forecast
+ensemble, observation, $\mathcal{H}$, $R$ — and produce a posterior
+ensemble.
+
+## How filters fail
+
+A finite ensemble in a chaotic system fails in characteristic ways, and
+the failure modes drive the design of every practical EnKF system:
+
+- **Spurious correlations.** With $N_e \ll N_x$, the sample covariance
+  contains $O(1/\sqrt{N_e})$ noise in every entry, including between
+  state components that are physically uncorrelated. A distant
+  observation then produces a confident, wrong increment. The cure is
+  *localization* — tapering covariances by distance — covered in
+  chapter 11.
+- **Variance underestimation and filter divergence.** Sampling error,
+  rank deficiency, and unmodelled error sources all bias the ensemble
+  spread low. An overconfident filter weights observations too little,
+  drifts from the truth, and eventually ignores the data entirely —
+  *filter divergence*. The cure is *inflation* — deliberately boosting
+  the spread — covered in chapter 12.
+
+Neither pathology appears in the equations of this chapter; both are
+consequences of $N_e$ being finite. Keep them in mind as the chapters
+proceed: the clean theory of chapters 2–5 is exact only as
+$N_e \to \infty$.
+
+## Where filterax sits
+
+filterax implements **analysis steps**: pure functions and lightweight
+`equinox` modules that take a forecast ensemble, an observation vector,
+an observation operator, and an observation-noise operator, and return
+the posterior ensemble. The forecast step — running $\mathcal{M}$ — is
+deliberately the caller's job: filterax never owns your dynamics. You
+can `jax.vmap` your own model over the ensemble, plug in a `diffrax`
+integrator, or use a neural emulator; the analysis step does not care.
+
+For multi-window experiments, the cycling itself (forecast → analyse →
+inflate, with history bookkeeping) is composed via the Layer-2 models
+(`filterax.StochasticEnKF`, `filterax.ETKF`, …) or, in larger pipelines,
+via `pipekit` cycles — chapter 16. Everything is JAX-native: every
+analysis step is `jit`-able, `vmap`-able, and differentiable.
+
+## Implementation in filterax
+
+A minimal forecast–analysis cycle with caller-owned dynamics:
+
+```python
+import jax
+import jax.numpy as jnp
+import lineax as lx
+from filterax.filters import StochasticEnKF
+
+key = jax.random.key(0)
+N_e, N_x = 20, 3
+
+def forecast(x):                     # M — the caller's model, used as-is
+    return 0.95 * x + 0.05 * jnp.roll(x, 1)
+
+def obs_op(x):                       # H — observe the first two components
+    return x[:2]
+
+R = lx.DiagonalLinearOperator(0.1 * jnp.ones(2))
+filt = StochasticEnKF(key=jax.random.key(1))
+
+X = jax.random.normal(key, (N_e, N_x))          # initial ensemble
+observations = [jnp.array([0.5, -0.2]), jnp.array([0.4, -0.1])]
+for t, y in enumerate(observations):
+    X = jax.vmap(forecast)(X)                   # forecast — caller's job
+    result = filt.analysis(X, y, obs_op, R, key=jax.random.fold_in(key, t))
+    X = result.particles                        # analysis — filterax's job
+```
+
+The `analysis` call is the entire interface. Each chapter that follows
+unpacks one piece of what happens inside it.
+
+## Where next
+
+- [Chapter 2 — Ensemble representation](02_ensemble_representation.md):
+  the $(N_e, N_x)$ matrix, anomalies, and the low-rank covariance.
+- [Chapter 3 — Observation model](03_observation_model.md): $\mathcal{H}$,
+  structured $R$, and perturbed observations.
+- [Chapter 4 — Kalman update](04_kalman_update.md): the BLUE gain and
+  its ensemble estimator.
+- [Chapter 5 — Stochastic EnKF](05_stochastic_enkf.md): the first
+  complete filter.
+- [Filters API](../api/filters.md) — the Layer-1 analysis steps and
+  Layer-2 cycling models.
+- [pipekit integration](../api/pipekit.md) — cycling in larger pipelines.
+
+## References
+
+- Kalman, R. E. (1960). *A new approach to linear filtering and
+  prediction problems.* J. Basic Eng. 82(1).
+- Evensen, G. (1994). *Sequential data assimilation with a nonlinear
+  quasi-geostrophic model using Monte Carlo methods to forecast error
+  statistics.* JGR Oceans 99(C5).
+- Evensen, G. (2003). *The Ensemble Kalman Filter: theoretical
+  formulation and practical implementation.* Ocean Dynamics 53.
+- Carrassi, A., Bocquet, M., Bertino, L., & Evensen, G. (2018). *Data
+  assimilation in the geosciences: An overview of methods, issues, and
+  perspectives.* WIREs Climate Change 9(5).
+- Vetra-Carvalho, S., et al. (2018). *State-of-the-art stochastic data
+  assimilation methods for high-dimensional non-Gaussian problems.*
+  Tellus A 70(1).

--- a/docs/math/02_ensemble_representation.md
+++ b/docs/math/02_ensemble_representation.md
@@ -1,0 +1,184 @@
+# Ensemble Representation
+
+The ensemble Kalman filter's central object is not a probability
+density but a finite sample from one. This chapter fixes the
+conventions — how the sample is laid out, how its moments are defined —
+and develops the one structural fact that everything downstream
+exploits: the sample covariance of $N_e$ members is a rank-deficient,
+low-rank matrix that never needs to be formed explicitly.
+
+## The ensemble matrix
+
+An ensemble of $N_e$ state vectors in $\mathbb{R}^{N_x}$ is stored as a
+matrix
+
+$$
+X = \begin{pmatrix} x^{(1)\top} \\ \vdots \\ x^{(N_e)\top} \end{pmatrix}
+\in \mathbb{R}^{N_e \times N_x},
+$$
+
+with **members as rows**: axis 0 is the ensemble axis, axis 1 the state
+axis. This matches the code throughout filterax — `particles[j]` is
+member $j$, and mapping a per-state function over the ensemble is
+`jax.vmap(fn)(particles)`. (Much of the DA literature writes the
+transpose, with members as columns; translate accordingly when
+comparing formulas.)
+
+The ensemble is a Monte Carlo representation of the filtering density:
+member $j$ is one plausible state, and probability statements become
+sample statistics over the rows.
+
+## Mean and anomalies
+
+The ensemble mean is the row average,
+
+$$
+\bar{x} = \frac{1}{N_e} \sum_{j=1}^{N_e} x^{(j)} \in \mathbb{R}^{N_x},
+$$
+
+and the **anomaly matrix** (centred perturbations) is
+
+$$
+X' = X - \mathbf{1}\bar{x}^\top \in \mathbb{R}^{N_e \times N_x},
+$$
+
+where $\mathbf{1} \in \mathbb{R}^{N_e}$ is the vector of ones. By
+construction the rows of $X'$ sum to zero — the anomalies live in the
+$(N_e - 1)$-dimensional subspace orthogonal to $\mathbf{1}$. The pair
+$(\bar{x}, X')$ carries exactly the same information as $X$, and most
+of the analysis algebra in chapters 4–5 is phrased on it: every
+ensemble Kalman filter is, in one form or another, a linear transform
+applied to these anomalies.
+
+## Sample covariance and the Bessel correction
+
+The (Bessel-corrected) sample covariance is
+
+$$
+P = \frac{1}{N_e - 1}\, X'^\top X' \in \mathbb{R}^{N_x \times N_x}.
+$$
+
+The divisor $N_e - 1$ rather than $N_e$ is the standard unbiasedness
+correction: centring on the *sample* mean $\bar{x}$ removes one degree
+of freedom, and dividing by $N_e$ would bias $P$ low by a factor
+$(N_e - 1)/N_e$. For $N_e = 20$ that is a 5% systematic
+underestimation of every variance — directly feeding the
+filter-divergence spiral of chapter 1. The EnKF literature and
+filterax both use $N_e - 1$ everywhere; this is why the package
+requires $N_e \ge 2$.
+
+## Rank and its consequences
+
+Because the rows of $X'$ sum to zero,
+
+$$
+\operatorname{rank}(P) \le N_e - 1,
+$$
+
+regardless of $N_x$. With $N_e = 50$ members and $N_x = 10^6$ state
+variables, the ensemble asserts that *all* forecast uncertainty lies in
+a 49-dimensional subspace. Two consequences matter in practice:
+
+- **The null space.** Directions outside the anomaly span have zero
+  sample variance: the filter is blind to errors there and will make no
+  correction along them. Analysis increments are always linear
+  combinations of the rows of $X'$ — the update cannot leave the
+  ensemble subspace.
+- **Spurious correlations.** Each off-diagonal entry of $P$ is an
+  average of $N_e$ products and carries sampling noise of order
+  $1/\sqrt{N_e}$. Physically uncorrelated state pairs therefore show
+  spurious sample correlations of typical size $1/\sqrt{N_e - 1}$
+  ($\approx 0.14$ for $N_e = 50$), which the Kalman update happily acts
+  on. Localization (chapter 11) suppresses them by tapering $P$ with
+  distance; inflation (chapter 12) compensates for the variance the
+  noise and the rank truncation lose.
+
+What looks like a defect is also the key computational fact: a rank-
+$(N_e - 1)$ matrix is fully described by its factors.
+
+## Covariance as a low-rank operator
+
+Define the scaled anomaly factor
+
+$$
+U = \frac{X'^\top}{\sqrt{N_e - 1}} \in \mathbb{R}^{N_x \times N_e},
+\qquad
+P = U U^\top.
+$$
+
+Every operation the filter needs from $P$ is available from $U$
+directly: a matrix–vector product $Pv = U(U^\top v)$ costs
+$O(N_e N_x)$; solves and log-determinants of $P$-plus-something go
+through the Woodbury identity and the matrix-determinant lemma at
+$O(N_e^2 N_x + N_e^3)$ instead of $O(N_x^3)$ (chapter 4 uses exactly
+this for the innovation covariance). The dense
+$(N_x, N_x)$ matrix is never needed — and at geophysical scale it
+would not fit in memory anyway.
+
+filterax enforces this structurally: `ensemble_covariance` returns a
+`gaussx.LowRankUpdate` linear operator built from $U$, **never a dense
+array**. The operator plugs into the `lineax`/`gaussx` ecosystem, where
+structural dispatch picks low-rank-aware algorithms for `solve`,
+`logdet`, and square roots automatically.
+
+## Implementation in filterax
+
+```python
+import gaussx
+import jax
+import jax.numpy as jnp
+from filterax import ensemble_anomalies, ensemble_covariance, ensemble_mean
+
+X = jax.random.normal(jax.random.key(0), (20, 500))   # N_e=20, N_x=500
+
+x_bar = ensemble_mean(X)          # x̄, shape (500,)
+X_prime = ensemble_anomalies(X)   # X′, shape (20, 500), rows sum to zero
+P = ensemble_covariance(X)        # P as a low-rank operator, rank ≤ 19
+
+assert isinstance(P, gaussx.LowRankUpdate)
+v = jnp.ones(500)
+Pv = P.mv(v)                      # P v without ever forming (500, 500)
+```
+
+All three functions are pure, `jit`-compatible, and differentiable.
+`ensemble_covariance` delegates to `gaussx.ensemble_covariance` with
+`bessel=True`, so the $1/(N_e - 1)$ convention is baked in; it raises
+`ValueError` if $N_e < 2$. The returned operator supports the full
+`lineax.AbstractLinearOperator` interface — `mv`, composition,
+`as_matrix()` (for small debugging cases only) — plus gaussx's
+structure-aware `solve` and `logdet`.
+
+The cross-covariance counterpart, `filterax.cross_covariance`, computes
+$C^{xH} = \frac{1}{N_e-1} X'^\top Y'$ between a state-space and an
+observation-space ensemble; it returns a dense $(N_x, N_y)$ array
+because $N_y$ is typically small. It is the workhorse of the Kalman
+gain in chapter 4.
+
+## Where next
+
+- [Chapter 3 — Observation model](03_observation_model.md): mapping the
+  ensemble into observation space, where the same mean/anomaly algebra
+  applies to $Y = \mathcal{H}(X)$.
+- [Chapter 4 — Kalman update](04_kalman_update.md): the gain
+  $K = C^{xH} S^{-1}$, where the low-rank structure of this chapter
+  pays off via Woodbury.
+- [Chapter 5 — Stochastic EnKF](05_stochastic_enkf.md): the first
+  complete analysis step built on these statistics.
+- [Primitives API](../api/primitives.md) — `ensemble_mean`,
+  `ensemble_anomalies`, `ensemble_covariance`, `cross_covariance`.
+- [Inflation API](../api/inflation.md) and
+  [Localization API](../api/localization.md) — the countermeasures to
+  sampling noise and rank deficiency.
+
+## References
+
+- Evensen, G. (2003). *The Ensemble Kalman Filter: theoretical
+  formulation and practical implementation.* Ocean Dynamics 53.
+- Houtekamer, P. L., & Mitchell, H. L. (1998). *Data assimilation using
+  an ensemble Kalman filter technique.* MWR 126(3).
+- Hamill, T. M., Whitaker, J. S., & Snyder, C. (2001).
+  *Distance-dependent filtering of background error covariance
+  estimates in an ensemble Kalman filter.* MWR 129(11).
+- Vetra-Carvalho, S., et al. (2018). *State-of-the-art stochastic data
+  assimilation methods for high-dimensional non-Gaussian problems.*
+  Tellus A 70(1).

--- a/docs/math/03_observation_model.md
+++ b/docs/math/03_observation_model.md
@@ -1,0 +1,210 @@
+# Observation Model
+
+The observation model is the bridge between the state the filter
+estimates and the data it actually sees. This chapter fixes the
+measurement equation, explains how ensembles handle nonlinear
+observation operators without ever linearising them explicitly, and
+introduces the two observation-space objects every analysis step
+consumes: the perturbed observations of the stochastic filters and the
+innovation statistics used for the update and for diagnostics.
+
+## The measurement equation
+
+Observations are modelled as a deterministic map of the true state plus
+additive Gaussian noise:
+
+$$
+y = \mathcal{H}(x) + \varepsilon, \qquad
+\varepsilon \sim \mathcal{N}(0, R),
+$$
+
+with $y \in \mathbb{R}^{N_y}$, the observation operator
+$\mathcal{H} : \mathbb{R}^{N_x} \to \mathbb{R}^{N_y}$, and the
+observation-error covariance $R \in \mathbb{R}^{N_y \times N_y}$.
+Equivalently, the likelihood is
+$p(y \mid x) = \mathcal{N}\!\big(y;\, \mathcal{H}(x),\, R\big)$.
+
+$\mathcal{H}$ can be as simple as a selection of grid points (point
+gauges), an interpolation stencil (satellite footprints), or a full
+radiative-transfer model (radiances). We write $\mathcal{H}$ for the
+general nonlinear operator and $H$ for a linear (or linearised) one,
+$y = Hx + \varepsilon$.
+
+## Linear versus nonlinear $\mathcal{H}$
+
+The classical Kalman update (chapter 4) needs the matrices $P H^\top$
+and $H P H^\top$ — it is built for linear $H$. The extended Kalman
+filter handles nonlinearity by differentiating $\mathcal{H}$
+analytically; ensembles do something simpler. Map every member through
+the full nonlinear operator, row-wise:
+
+$$
+Y = \mathcal{H}(X) \in \mathbb{R}^{N_e \times N_y},
+\qquad
+Y_{j\cdot} = \mathcal{H}\big(x^{(j)}\big)^\top,
+$$
+
+and form observation-space mean and anomalies exactly as in chapter 2:
+
+$$
+\bar{y} = \frac{1}{N_e} \sum_{j=1}^{N_e} \mathcal{H}\big(x^{(j)}\big),
+\qquad
+Y' = Y - \mathbf{1}\bar{y}^\top.
+$$
+
+The substitutions $X' H^\top \to Y'$ then turn every appearance of $H$
+in the Kalman algebra into a sample statistic:
+
+$$
+P H^\top \;\to\; C^{xH} = \frac{1}{N_e - 1} X'^\top Y',
+\qquad
+H P H^\top \;\to\; C^{HH} = \frac{1}{N_e - 1} Y'^\top Y'.
+$$
+
+For linear $H$ these are exact (then $Y' = X' H^\top$ identically).
+For nonlinear $\mathcal{H}$, the ensemble provides an implicit,
+derivative-free **statistical linearisation**: the regression of
+observation-space anomalies on state-space anomalies, evaluated where
+the ensemble actually is. No tangent-linear code, no Jacobian — the
+caller supplies $\mathcal{H}$ as a plain callable on a single state
+vector and filterax `vmap`s it over the rows.
+
+## Structured $R$
+
+filterax never accepts $R$ as a raw dense array: it is always a
+`lineax.AbstractLinearOperator`, so its structure is visible to the
+linear algebra downstream. The overwhelmingly common case is
+uncorrelated instrument noise,
+
+$$
+R = \operatorname{diag}\big(\sigma_1^2, \dots, \sigma_{N_y}^2\big),
+$$
+
+passed as `lineax.DiagonalLinearOperator(variances)` — solves are
+pointwise divisions and sampling needs only the square roots of the
+diagonal. Correlated errors (e.g. spatially correlated satellite
+retrievals) can be passed as any structured operator — low-rank,
+Toeplitz, Kronecker — and gaussx's structural dispatch keeps solves and
+square roots cheap. Only a genuinely dense $R$ falls back to a dense
+Cholesky, and even then the $O(N_y^3)$ factorisation is amortised
+across the ensemble.
+
+## Perturbed observations
+
+Stochastic filters (chapter 5) require each member to be updated
+against its own noisy copy of the data,
+
+$$
+y^{(j)}_{\text{pert}} = y + \varepsilon^{(j)}, \qquad
+\varepsilon^{(j)} \sim \mathcal{N}(0, R), \qquad
+j = 1, \dots, N_e,
+$$
+
+so the observation error enters the analysis ensemble with the correct
+covariance (the *why* is chapter 5's subject). The draws are zero-mean,
+so the perturbed set preserves the observation in expectation,
+$\mathbb{E}\big[y^{(j)}_{\text{pert}}\big] = y$; the realised sample
+mean of $N_e$ draws still deviates from $y$ by $O(1/\sqrt{N_e})$,
+which is part of the stochastic filter's Monte Carlo noise budget.
+
+In filterax the draw is structure-aware: for diagonal $R$ the
+perturbations are $\varepsilon^{(j)} = z^{(j)} \odot \sqrt{\operatorname{diag}(R)}$
+with standard-normal $z^{(j)}$ at $O(N_e N_y)$ cost and no matrix ever
+formed; for general $R$ a structured square root $L$ with
+$LL^\top = R$ comes from `gaussx.root_decomposition` and
+$\varepsilon^{(j)} = L z^{(j)}$.
+
+## Innovation statistics
+
+The **innovation** is the observation-space misfit of the forecast,
+
+$$
+d = y - \mathcal{H}(\bar{x}),
+$$
+
+where in ensemble practice $\mathcal{H}(\bar{x})$ is computed as the
+ensemble mean $\bar{y}$ of $Y = \mathcal{H}(X)$ (the two coincide for
+linear $H$). Under the Gaussian model the innovation has zero mean and
+covariance
+
+$$
+S = C^{HH} + R,
+$$
+
+the **innovation covariance**: forecast uncertainty as seen through
+$\mathcal{H}$, plus observation noise. $S$ is the matrix the Kalman
+gain inverts (chapter 4), and it is also the filter's self-diagnosis
+instrument:
+
+- the **log-likelihood** of the data under the forecast,
+  $\log p(y \mid \text{forecast}) = -\tfrac{1}{2}\big[N_y \log 2\pi +
+  \log\lvert S\rvert + d^\top S^{-1} d\big]$, is the training signal
+  for differentiable DA;
+- the **whitened innovation** $S^{-1/2} d$ should be standard normal
+  component-wise when $P$, $R$, and $\mathcal{H}$ are all correctly
+  specified — the basis of $\chi^2$ and Desroziers-style consistency
+  checks.
+
+Because $C^{HH}$ has rank $\le N_e - 1$, filterax assembles $S$ as a
+`gaussx.LowRankUpdate` over the structured $R$ base, and both
+$\log\lvert S\rvert$ and $S^{-1}d$ go through the matrix-determinant
+lemma and the Woodbury identity at $O(N_e^2 N_y + N_e^3)$.
+
+## Implementation in filterax
+
+```python
+import jax
+import jax.numpy as jnp
+import lineax as lx
+from filterax import innovation_statistics, perturbed_observations
+
+N_e, N_x, N_y = 30, 8, 3
+X = jax.random.normal(jax.random.key(0), (N_e, N_x))   # forecast ensemble
+
+def obs_op(x):                       # nonlinear H on a single state vector
+    return jnp.tanh(x[:3])
+
+y = jnp.array([0.3, -0.1, 0.2])
+R = lx.DiagonalLinearOperator(0.05 * jnp.ones(N_y))
+
+# Innovation d, S = C^HH + R (as a LowRankUpdate), whitened residual,
+# and log p(y | forecast) — obs_op is vmapped over the rows internally.
+stats = innovation_statistics(X, y, obs_op, R)
+stats["innovation"]                  # (3,)
+stats["normalized_innovation"]       # S^{-1/2} d — unit-variance if consistent
+stats["log_likelihood"]              # scalar training/diagnostic signal
+
+# Perturbed observations for the stochastic EnKF (chapter 5).
+y_pert = perturbed_observations(jax.random.key(1), y, R, N_e)   # (30, 3)
+```
+
+The `obs_op` argument is any callable from a single state vector to a
+single observation vector; linear operators, interpolators, and learned
+networks all qualify. `perturbed_observations` consumes an explicit
+PRNG key — pass a fresh key per assimilation window, or successive
+windows will see identical perturbations.
+
+## Where next
+
+- [Chapter 4 — Kalman update](04_kalman_update.md): the gain
+  $K = C^{xH} S^{-1}$ built from this chapter's $Y'$, $R$, and $S$.
+- [Chapter 5 — Stochastic EnKF](05_stochastic_enkf.md): where
+  `perturbed_observations` earns its keep.
+- [Chapter 2 — Ensemble representation](02_ensemble_representation.md):
+  the mean/anomaly algebra reused here in observation space.
+- [Primitives API](../api/primitives.md) — `innovation_covariance`,
+  `innovation_statistics`, `log_likelihood`, `perturbed_observations`.
+- [Diagnostics API](../api/diagnostics.md) — rank histograms, spread
+  and consistency checks built on the innovation statistics.
+
+## References
+
+- Burgers, G., van Leeuwen, P. J., & Evensen, G. (1998). *Analysis
+  scheme in the ensemble Kalman filter.* MWR 126(6).
+- Desroziers, G., Berre, L., Chapnik, B., & Poli, P. (2005).
+  *Diagnosis of observation, background and analysis-error statistics
+  in observation space.* QJRMS 131(613).
+- Janjić, T., et al. (2018). *On the representation error in data
+  assimilation.* QJRMS 144(713).
+- Evensen, G. (2003). *The Ensemble Kalman Filter: theoretical
+  formulation and practical implementation.* Ocean Dynamics 53. §5.

--- a/docs/math/04_kalman_update.md
+++ b/docs/math/04_kalman_update.md
@@ -1,0 +1,184 @@
+# Kalman Update and the Ensemble Gain
+
+The analysis step of every filter in this library is built around one
+matrix: the Kalman gain. This chapter derives it as the best linear
+unbiased estimator, translates it into ensemble statistics, and then
+turns to the computational question that shapes filterax's design —
+how to apply $S^{-1}$ when $S$ is large but structured.
+
+## The best linear unbiased update
+
+Let $x^f$ be the forecast state with error covariance $P$, and let
+$y = Hx + \varepsilon$ with $\varepsilon \sim \mathcal{N}(0, R)$ be an
+observation (linear $H$ for the derivation; the ensemble handles
+nonlinear $\mathcal{H}$ by the implicit linearisation of chapter 3).
+Seek an estimator that is linear in the innovation $d = y - Hx^f$:
+
+$$
+x^a = x^f + K d.
+$$
+
+Unbiasedness is automatic ($\mathbb{E}[d] = 0$ when forecast and
+observation errors are zero-mean). Choosing $K$ to minimise the total
+posterior variance $\operatorname{tr}(P^a)$, where
+$P^a = (I - KH) P (I - KH)^\top + K R K^\top$, gives by differentiating
+in $K$ and setting the result to zero:
+
+$$
+K = P H^\top \big(H P H^\top + R\big)^{-1}.
+$$
+
+This is the BLUE — the *best linear unbiased estimator* — and, in the
+linear-Gaussian case, also the exact Bayesian posterior mean, with
+posterior covariance $P^a = (I - KH)P$. The gain has a clean reading:
+it is the regression coefficient of state error on innovation,
+"uncertainty in the state as seen by the observations, divided by the
+total uncertainty of the observations themselves."
+
+## The ensemble gain
+
+Ensembles never form $P$. Substituting the sample statistics of
+chapters 2–3 — $P H^\top \to C^{xH}$, $H P H^\top \to C^{HH}$ — the
+gain becomes
+
+$$
+K = C^{xH} S^{-1}, \qquad S = C^{HH} + R,
+$$
+
+with
+
+$$
+C^{xH} = \frac{1}{N_e - 1} X'^\top Y'
+\in \mathbb{R}^{N_x \times N_y},
+\qquad
+C^{HH} = \frac{1}{N_e - 1} Y'^\top Y'
+\in \mathbb{R}^{N_y \times N_y}.
+$$
+
+Everything is built from the two anomaly matrices. $C^{xH}$ is computed
+densely — it is $(N_x, N_y)$ and $N_y$ is typically small — and the
+interesting question is the solve against $S$.
+
+## Assembling $S$ as a low-rank update
+
+$C^{HH}$ has rank $\le N_e - 1$ (chapter 2), so $S$ is a structured
+$R$ plus a low-rank term:
+
+$$
+S = R + U U^\top, \qquad U = \frac{Y'^\top}{\sqrt{N_e - 1}}
+\in \mathbb{R}^{N_y \times N_e}.
+$$
+
+filterax assembles exactly this object — a `gaussx.LowRankUpdate` with
+base $R$ and factor $U$ — and never the dense $(N_y, N_y)$ matrix.
+Structural dispatch in gaussx then routes the solve through the
+**Woodbury identity** (quoting the implementation's own formula, with
+$(HX)'$ the observation-space anomalies $Y'$):
+
+$$
+S^{-1} = R^{-1} - R^{-1} U
+    \left( (N_{e} - 1) I + U^{\top} R^{-1} U \right)^{-1}
+    U^{\top} R^{-1},
+\qquad
+U = \frac{(HX)^{\prime\top}}{\sqrt{N_{e} - 1}}.
+$$
+
+Only the small $(N_e, N_e)$ inner matrix is ever factorised. When
+$R^{-1}$ is cheap (diagonal, low-rank, Toeplitz, …), applying $S^{-1}$
+costs
+
+$$
+O\big(N_e^2 N_y + N_e^3\big)
+\qquad \text{instead of} \qquad
+O\big(N_y^3\big)
+$$
+
+for the dense factorisation. The distinction is decisive whenever
+$N_y \gg N_e$ — a satellite swath with $N_y \sim 10^5$ observations and
+$N_e = 50$ members costs millions of flops through Woodbury versus
+$\sim 10^{15}$ dense. The same structure gives $\log\lvert S \rvert$
+through the matrix-determinant lemma, which is how the innovation
+log-likelihood of chapter 3 stays cheap.
+
+The gain itself, $K = C^{xH} S^{-1}$, is materialised as a dense
+$(N_x, N_y)$ array deliberately: it is consumed once by the analysis
+update, and $N_y$ is the per-window observation count, not the state
+dimension.
+
+## Localized gains
+
+The raw ensemble gain inherits the sampling noise of $C^{xH}$
+(chapter 2): a distant, physically unrelated observation gets a
+non-zero gain row of typical size $1/\sqrt{N_e - 1}$. The practical
+remedy is Schur-product localization,
+
+$$
+K = (\rho^{xy} \circ C^{xH})\,(\rho^{yy} \circ C^{HH} + R)^{-1},
+$$
+
+with distance-based tapers $\rho$ (Gaspari–Cohn and friends). The
+Hadamard product destroys the low-rank structure of $C^{HH}$, so the
+localized gain pays the dense $O(N_y^3)$ price — one of several
+trade-offs covered properly in chapter 11. In filterax this is
+`localized_kalman_gain`, which reduces exactly to the plain gain when
+$\rho \equiv 1$.
+
+## Implementation in filterax
+
+```python
+import jax
+import jax.numpy as jnp
+import lineax as lx
+from filterax import kalman_gain
+
+N_e, N_x, N_y = 25, 40, 10
+X = jax.random.normal(jax.random.key(0), (N_e, N_x))   # forecast ensemble
+Y = X[:, :N_y]                     # linear H: observe the first 10 components
+R = lx.DiagonalLinearOperator(0.2 * jnp.ones(N_y))
+
+K = kalman_gain(X, Y, R)           # (40, 10) — Woodbury solve inside
+
+# Sanity check against the dense textbook formula.
+Xp = X - X.mean(axis=0)
+Yp = Y - Y.mean(axis=0)
+C_xH = Xp.T @ Yp / (N_e - 1)
+S = Yp.T @ Yp / (N_e - 1) + 0.2 * jnp.eye(N_y)
+K_dense = C_xH @ jnp.linalg.inv(S)
+assert jnp.allclose(K, K_dense, atol=1e-4)
+```
+
+`kalman_gain(particles, obs_particles, obs_noise)` takes the state
+ensemble $X$, the observation-space ensemble $Y = \mathcal{H}(X)$ (for
+nonlinear $\mathcal{H}$, apply your callable via `jax.vmap` first or
+let the filter classes do it), and $R$ as a `lineax` operator. The
+optional `solver=` keyword overrides gaussx's structural dispatch; the
+default picks Woodbury for low-rank-over-structured-$R$ and a dense
+Cholesky otherwise. Like all primitives, the function is pure,
+`jit`-compatible, and differentiable end-to-end.
+
+## Where next
+
+- [Chapter 5 — Stochastic EnKF](05_stochastic_enkf.md): the first
+  complete filter built on this gain — one $K$, applied to every
+  member's own perturbed innovation.
+- [Chapter 2 — Ensemble representation](02_ensemble_representation.md):
+  why $C^{HH}$ is rank-deficient, and why that is good news here.
+- [Chapter 3 — Observation model](03_observation_model.md): where $Y$,
+  $S$, and the innovation come from.
+- [Primitives API](../api/primitives.md) — `kalman_gain`,
+  `cross_covariance`, `innovation_covariance`.
+- [Localization API](../api/localization.md) —
+  `localized_kalman_gain`, `gaspari_cohn`, `localization_matrix`.
+
+## References
+
+- Kalman, R. E. (1960). *A new approach to linear filtering and
+  prediction problems.* J. Basic Eng. 82(1).
+- Evensen, G. (2003). *The Ensemble Kalman Filter: theoretical
+  formulation and practical implementation.* Ocean Dynamics 53.
+- Hager, W. W. (1989). *Updating the inverse of a matrix.* SIAM Review
+  31(2). (The Woodbury identity and its history.)
+- Tippett, M. K., Anderson, J. L., Bishop, C. H., Hamill, T. M., &
+  Whitaker, J. S. (2003). *Ensemble square root filters.* MWR 131(7).
+- Gaspari, G., & Cohn, S. E. (1999). *Construction of correlation
+  functions in two and three dimensions.* QJRMS 125(554).

--- a/docs/math/05_stochastic_enkf.md
+++ b/docs/math/05_stochastic_enkf.md
@@ -1,0 +1,199 @@
+# The Stochastic EnKF
+
+The stochastic ensemble Kalman filter (Evensen 1994; Burgers, van
+Leeuwen & Evensen 1998) is the original and simplest member of the EnKF
+family: compute one Kalman gain from the forecast ensemble, then update
+every member against its own randomly perturbed copy of the
+observation. This chapter states the update, explains why the
+perturbations are not optional, and quantifies the price they carry.
+
+## The perturbed-observation update
+
+Given the forecast ensemble $X \in \mathbb{R}^{N_e \times N_x}$, the
+observation $y$, and the gain $K = C^{xH} S^{-1}$ of chapter 4, each
+member is updated as
+
+$$
+x_j^a = x_j^f + K\big(y_j - \mathcal{H}(x_j^f)\big),
+\qquad
+y_j = y + \epsilon_j,
+\qquad
+\epsilon_j \sim \mathcal{N}(0, R),
+$$
+
+for $j = 1, \dots, N_e$ — the perturbed observations of chapter 3.
+Three points to note:
+
+- **One gain, $N_e$ innovations.** $K$ is computed once from the
+  forecast statistics; only the per-member innovation
+  $y_j - \mathcal{H}(x_j^f)$ varies across members.
+- **Per-member innovations, not the mean innovation.** Each member is
+  pulled toward the data from *its own* position in observation space,
+  so the update reshapes the whole ensemble, not just its mean.
+- **Independent perturbations.** The $\epsilon_j$ are i.i.d. draws;
+  reusing a draw across members (or across assimilation windows)
+  silently breaks the covariance argument below.
+
+Averaging over $j$ shows the analysis mean satisfies the standard
+Kalman update $\bar{x}^a = \bar{x}^f + K\,d$ up to the
+$O(1/\sqrt{N_e})$ sample mean of the perturbations, with
+$d = y - \mathcal{H}(\bar{x})$ the usual innovation.
+
+## Why the perturbations are necessary
+
+The natural first attempt — update every member with the same,
+unperturbed $y$ — is *wrong*, and the failure is systematic, not
+random. Subtracting the mean update from the member update shows what
+happens to the anomalies. Without perturbations (linear $H$ for
+clarity):
+
+$$
+X'^a = X'^f (I - KH)^\top
+\quad\Longrightarrow\quad
+P^a_{\text{no pert}} = (I - KH)\, P\, (I - KH)^\top,
+$$
+
+whereas the correct Bayesian posterior covariance is
+
+$$
+P^a = (I - KH)\, P
+= (I - KH)\, P\, (I - KH)^\top + K R K^\top.
+$$
+
+The unperturbed ensemble is missing exactly the $K R K^\top$ term — the
+posterior uncertainty contributed by observation noise. Its spread is
+therefore biased low at *every* analysis, the bias compounds over
+cycles, and the filter spirals into the divergence failure mode of
+chapter 1: too confident, deaf to data.
+
+Burgers, van Leeuwen & Evensen (1998) showed that treating the
+observation as a random variable restores the missing term. With
+perturbed observations, the analysis anomalies become
+
+$$
+X'^a = X'^f (I - KH)^\top + E' K^\top,
+$$
+
+where $E'$ collects the centred perturbations $\epsilon_j$. Since the
+perturbations are independent of the forecast errors and have
+covariance $R$, taking expectations gives
+
+$$
+\mathbb{E}\big[P^a_{\text{pert}}\big]
+= (I - KH)\, P\, (I - KH)^\top + K R K^\top
+= (I - KH)\, P.
+$$
+
+The stochastic EnKF is thus a correct Monte Carlo sampler of the
+Kalman posterior — in expectation, and exactly in the limit
+$N_e \to \infty$.
+
+## The price: sampling noise
+
+"In expectation" is the catch. For finite $N_e$ the realised
+perturbations have a sample mean and sample covariance that deviate
+from $(0, R)$ by $O(1/\sqrt{N_e})$, and these deviations propagate
+through $K$ into the analysis ensemble as extra Monte Carlo variance on
+top of the sampling error the forecast ensemble already carries. With
+small ensembles ($N_e \lesssim 50$, the operationally relevant regime)
+this added noise is measurable: noisier analysis means, noisier
+spread, more work for inflation.
+
+The deterministic square-root filters (ETKF, EnSRF — chapters 6–7)
+remove this noise source entirely: they achieve the correct posterior
+covariance by an exact linear transform of the anomalies instead of by
+random perturbation. The trade-off is not one-sided — the stochastic
+filter's randomness makes it more robust to some nonlinear and
+non-Gaussian effects, it never develops the preferred-direction
+artefacts that deterministic transforms can, and it is the natural
+bridge to randomised algorithms (EKI and friends). As a default,
+though: prefer square-root filters at small $N_e$; the stochastic EnKF
+remains the reference implementation and the simplest thing that is
+actually correct.
+
+## Algorithm
+
+```
+Inputs: X (N_e, N_x) forecast ensemble; y (N_y,) observation;
+        H obs operator; R obs-noise operator; key PRNG key
+
+Y   = H(X) row-wise                          # (N_e, N_y), chapter 3
+K   = C^xH (C^HH + R)^{-1}                   # (N_x, N_y), chapter 4 (Woodbury)
+Y_p = y + E,  E ~ N(0, R) per row            # (N_e, N_y) perturbed obs
+X_a = X + (Y_p - Y) K^T                      # per-member update
+return X_a, log p(y | forecast)              # likelihood from S = C^HH + R
+```
+
+Cost per analysis: $O(N_e \cdot \text{cost}(\mathcal{H}))$ for the
+observation-space ensemble, $O(N_e^2 N_y + N_e^3)$ for the gain via
+Woodbury, $O(N_e N_x N_y)$ to apply it.
+
+## Implementation in filterax
+
+```python
+import jax
+import jax.numpy as jnp
+import lineax as lx
+from filterax.filters import StochasticEnKF
+
+N_e, N_x, N_y = 50, 6, 2
+X = jax.random.normal(jax.random.key(0), (N_e, N_x)) + 2.0   # forecast
+
+def obs_op(x):                       # H: observe the first two components
+    return x[:2]
+
+y = jnp.array([1.5, 2.5])
+R = lx.DiagonalLinearOperator(0.25 * jnp.ones(N_y))
+
+filt = StochasticEnKF(key=jax.random.key(0))
+result = filt.analysis(X, y, obs_op, R, key=jax.random.key(42))
+
+result.particles          # (50, 6) analysis ensemble
+result.log_likelihood     # log p(y | forecast) under S = C^HH + R
+```
+
+`filterax.filters.StochasticEnKF` is the Layer-1 analysis step: one
+forecast ensemble in, one posterior ensemble out, as an
+`AnalysisResult`. The PRNG key stored on the filter is only the
+*default*; pass a fresh `key=` per call (as above) or successive
+windows will reuse identical observation perturbations — exactly the
+correlated-draws mistake the theory forbids. The Layer-2 model
+`filterax.StochasticEnKF` (top level, same name) wraps this step in the
+full forecast → analyse → inflate loop and threads sub-keys per window
+automatically; chapter 1's example shows the Layer-1 cycle written by
+hand.
+
+Everything inside `analysis` is assembled from the primitives of the
+previous chapters: `kalman_gain` (chapter 4), `perturbed_observations`
+(chapter 3), and the innovation likelihood under
+$S = C^{HH} + R$. The step is `jit`-compatible and differentiable,
+which is what makes the filter usable inside training loops.
+
+## Where next
+
+- [Chapter 4 — Kalman update](04_kalman_update.md): the gain this
+  filter applies, and the Woodbury solve behind it.
+- [Chapter 3 — Observation model](03_observation_model.md):
+  perturbed observations and innovation statistics.
+- [Chapter 1 — Problem setting](01_problem_setting.md): the
+  forecast–analysis cycle this step slots into, and the divergence
+  failure modes that inflation (chapter 12) and localization
+  (chapter 11) address.
+- [Filters API](../api/filters.md) — `filterax.filters.StochasticEnKF`
+  (analysis step) and `filterax.StochasticEnKF` (cycling model).
+- [Differentiable training API](../api/differentiable.md) — using the
+  analysis log-likelihood as a learning signal.
+
+## References
+
+- Evensen, G. (1994). *Sequential data assimilation with a nonlinear
+  quasi-geostrophic model using Monte Carlo methods to forecast error
+  statistics.* JGR Oceans 99(C5).
+- Burgers, G., van Leeuwen, P. J., & Evensen, G. (1998). *Analysis
+  scheme in the ensemble Kalman filter.* MWR 126(6).
+- Houtekamer, P. L., & Mitchell, H. L. (1998). *Data assimilation using
+  an ensemble Kalman filter technique.* MWR 126(3).
+- Tippett, M. K., Anderson, J. L., Bishop, C. H., Hamill, T. M., &
+  Whitaker, J. S. (2003). *Ensemble square root filters.* MWR 131(7).
+- van Leeuwen, P. J. (2020). *A consistent interpretation of the
+  stochastic version of the Ensemble Kalman Filter.* QJRMS 146(731).

--- a/docs/math/06_etkf.md
+++ b/docs/math/06_etkf.md
@@ -1,0 +1,245 @@
+# ETKF — Ensemble Transform Kalman Filter
+
+The stochastic EnKF (chapter 5) gets the analysis covariance right only
+*in expectation* — every member sees its own perturbed observation, and
+those draws add $O(1/\sqrt{N_e})$ Monte Carlo noise to the update. The
+ETKF (Bishop, Etherton & Majumdar 2001) removes the sampling step
+entirely: it computes a single deterministic *transform* of the
+forecast ensemble whose sample mean and sample covariance match the
+Kalman analysis exactly.
+
+## The ensemble-space ansatz
+
+Recall the conventions from chapter 2: the ensemble matrix
+$X \in \mathbb{R}^{N_e \times N_x}$ holds members as rows,
+$\bar{x}$ is the ensemble mean, $X' = X - \mathbf{1}\bar{x}^\top$ the
+anomalies, and $P = \frac{1}{N_e-1} X'^\top X'$ the sample covariance.
+The observed ensemble is $Y = \mathcal{H}(X)$ with anomalies $Y'$ and
+innovation $d = y - \bar{y}$.
+
+The key observation: the Kalman update only ever moves the state within
+the span of the forecast anomalies. So instead of working with
+$N_x \times N_x$ covariances, write the analysis as a *weighted
+recombination of the forecast members* and solve for the weights. Define
+the ensemble-space transform precision
+
+$$
+\tilde{C} = (N_e - 1)\, I + Y' R^{-1} Y'^{\top}
+    \in \mathbb{R}^{N_e \times N_e}, \qquad
+T = \tilde{C}^{-1}.
+$$
+
+(With members as rows, $Y' R^{-1} Y'^\top$ is the $N_e \times N_e$
+inner-product matrix; texts that store members as columns write the
+transposes the other way around.) The mean weights and the transform:
+
+$$
+\bar{w} = T\, Y' R^{-1} d, \qquad
+W = \sqrt{(N_e - 1)\, T},
+$$
+
+and the analysis ensemble is assembled entirely from forecast anomalies:
+
+$$
+\bar{x}_a = \bar{x} + \bar{w}^{\top} X', \qquad
+X'_a = W X', \qquad
+X_a = \mathbf{1}\bar{x}_a^{\top} + X'_a.
+$$
+
+A short calculation (substitute $C^{HH} = \frac{1}{N_e-1}Y'^\top Y'$
+and apply the Sherman-Morrison-Woodbury identity to
+$S = C^{HH} + R$) shows that $\bar{x}_a$ equals the Kalman mean
+$\bar{x} + K d$ and that
+$\frac{1}{N_e-1} X_a'^\top X_a' = (I - KH)\,P$ — the analysis
+covariance is exact with respect to the sample statistics, with no
+randomness anywhere. The conformance test
+`test_etkf_matches_kalman_in_linear_gaussian` pins this to
+`atol = 1e-9`.
+
+## Why the symmetric square root
+
+$T$ is symmetric positive definite, so it has infinitely many square
+roots: any $W = T^{1/2} U$ with $U$ orthogonal reproduces the same
+analysis covariance. They do **not** all produce a valid ensemble. The
+anomalies must stay mean-zero — $\mathbf{1}^\top X'_a = 0$ — otherwise
+the sample mean of $X_a$ silently drifts away from the Kalman mean
+$\bar{x}_a$ and the filter is biased.
+
+Because anomaly rows sum to zero ($Y'^\top \mathbf{1} = 0$), the
+constant vector is an eigenvector of $\tilde{C}$:
+
+$$
+\tilde{C}\, \mathbf{1} = (N_e - 1)\, \mathbf{1}
+\quad\Longrightarrow\quad
+W \mathbf{1} = \sqrt{(N_e - 1) \cdot \tfrac{1}{N_e - 1}}\; \mathbf{1}
+             = \mathbf{1}
+$$
+
+for the *symmetric* square root
+$W = U_C \sqrt{(N_e-1)\Lambda^{-1}}\, U_C^\top$ (where
+$\tilde{C} = U_C \Lambda U_C^\top$). Then
+$\mathbf{1}^\top W X' = (W\mathbf{1})^\top X' = \mathbf{1}^\top X' = 0$:
+the transform maps mean-zero anomalies to mean-zero anomalies. Tippett
+et al. (2003) and Livings et al. (2008) show the symmetric choice is the
+unique PSD square root with this property — any other rotation either
+breaks the mean or loses positive semi-definiteness. filterax's `EnSRF`
+(chapter 7) uses exactly the same symmetric transform for its
+perturbation half.
+
+## Differentiability — the QR + small-eigh spectrum
+
+This subsection is the reason filterax carries its own ETKF core rather
+than delegating to `gaussx.etkf_transform`.
+
+The textbook recipe eigendecomposes the full $N_e \times N_e$ matrix
+$\tilde{C}$. But $Y' R^{-1} Y'^\top$ has rank at most $N_y$, so
+$\tilde{C}$ has $N_e - N_y$ eigenvalues *structurally equal* to
+$N_e - 1$. Forward-mode that is harmless; in reverse mode, the
+JVP/VJP rule for `eigh` divides by pairwise eigenvalue gaps
+$\lambda_i - \lambda_j$, and repeated eigenvalues produce `NaN`
+gradients. Any training loop that backpropagates through the analysis
+(chapter 14) would die on the very first step.
+
+filterax sidesteps the degenerate subspace instead of regularising it:
+
+1. Thin QR: $Y' = Q\, R_{qr}$ with $Q \in \mathbb{R}^{N_e \times N_y}$.
+2. Form the small symmetric PSD matrix
+   $M_y = R_{qr} R^{-1} R_{qr}^\top \in \mathbb{R}^{N_y \times N_y}$
+   and eigendecompose it: $M_y = V \operatorname{diag}(\lambda_i) V^\top$.
+3. Lift: $U_y = Q V$ gives
+   $Y' R^{-1} Y'^\top = U_y \operatorname{diag}(\lambda_i) U_y^\top$.
+
+Every matrix function of $\tilde{C}$ then takes the rank-$N_y$
+correction form
+
+$$
+g(\tilde{C}) = g(N_e - 1)\, I
+    + U_y\, \operatorname{diag}\!\big(g(N_e - 1 + \lambda_i) - g(N_e - 1)\big)\, U_y^{\top},
+$$
+
+used twice per analysis: $g(\lambda) = 1/\lambda$ for $T$ and
+$g(\lambda) = \sqrt{(N_e-1)/\lambda}$ for $W$. The degenerate
+eigenvalues never meet an `eigh`, the small $(N_y, N_y)$ problem has
+generically distinct eigenvalues, and `jax.grad` through the whole
+analysis is finite. The solve $R^{-1} Y'$ routes through gaussx
+structural dispatch, so a diagonal $R$ never densifies.
+
+## ETKF_Livings — breaking the deterministic symmetry
+
+The symmetric transform is deterministic, and over hundreds of cycles
+the same $W$-shaped contraction can develop preferred directions: the
+ensemble drifts toward a small invariant subspace and the higher
+moments become non-Gaussian. Livings et al. (2008) compose the
+transform with a *random mean-preserving rotation*
+
+$$
+W^{\mathrm{rot}} = W\, \Theta, \qquad
+\Theta \in O(N_e), \quad \Theta\, \mathbf{1} = \mathbf{1},
+$$
+
+built by drawing a uniform rotation in the $(N_e - 1)$-dimensional
+complement of $\mathbf{1}$ (QR of a Gaussian matrix) and lifting it back
+with a Householder basis. The constraint $\Theta\mathbf{1} = \mathbf{1}$
+keeps the analysis mean and the mean-zero anomaly property exactly; the
+randomness averages out preferred-direction artefacts over time. Use a
+fresh `key` per cycle — repeating the same rotation every window
+defeats the purpose.
+
+## Implementation in filterax
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+
+import filterax as flx
+
+# Forecast ensemble: N_e = 30 members of a 4-dimensional state.
+particles = 1.0 + 0.5 * jr.normal(jr.key(0), (30, 4))
+
+# Observe components 0 and 2 with independent noise.
+H = jnp.zeros((2, 4)).at[0, 0].set(1.0).at[1, 2].set(1.0)
+obs = jnp.array([0.4, -0.1])
+R = lx.DiagonalLinearOperator(0.1 * jnp.ones(2))
+
+result = flx.filters.ETKF().analysis(particles, obs, lambda x: H @ x, R)
+result.particles.shape         # (30, 4)
+result.log_likelihood          # Gaussian log p(d | S), for diagnostics
+
+# Observed components contract; unobserved ones barely move.
+particles.std(axis=0, ddof=1)         # [0.401, 0.497, 0.473, 0.497]
+result.particles.std(axis=0, ddof=1)  # [0.248, 0.491, 0.263, 0.484]
+
+# Livings variant: same mean, randomly rotated perturbations.
+rotated = flx.filters.ETKF_Livings(key=jr.key(1)).analysis(
+    particles, obs, lambda x: H @ x, R, key=jr.key(2)
+)
+jnp.allclose(
+    rotated.particles.mean(axis=0), result.particles.mean(axis=0), atol=1e-5
+)  # True
+
+# The analysis is differentiable end-to-end (the QR + small-eigh core).
+import jax
+
+def posterior_spread(scale):
+    res = flx.filters.ETKF().analysis(scale * particles, obs, lambda x: H @ x, R)
+    return res.particles.std(axis=0, ddof=1).sum()
+
+jax.grad(posterior_spread)(1.0)  # finite — no repeated-eigenvalue NaN
+```
+
+`filterax.filters.ETKF` is the Layer-1 analysis step: one posterior
+ensemble from one observation vector. The Layer-2 `filterax.ETKF`
+wraps it with dynamics, inflation, and the multi-window `assimilate()`
+loop (chapter 16).
+
+## Cost
+
+Per analysis: $O(N_e N_y^2)$ for the thin QR and the small eigh,
+$O(N_e^2 N_y)$ for assembling the weights, $O(N_e^2 N_x)$ for applying
+them — all independent of $N_x^2$. The transform never touches an
+$N_x \times N_x$ or (for structured $R$) an $N_y \times N_y$ dense
+matrix. For $N_y > N_e$ the QR-based spectrum no longer applies
+directly; batch the observations or use domain localization
+(chapter 8), which makes every local $N_y$ small.
+
+## When ETKF is the right answer
+
+- Deterministic, reproducible analyses — no perturbation noise.
+- Small-to-moderate ensembles where the stochastic EnKF's
+  $O(1/\sqrt{N_e})$ sampling error is the dominant error term.
+- Differentiable pipelines — gradient-safe by construction.
+- As the inner solver for LETKF (chapter 8), which runs one ETKF per
+  grid point.
+
+Reach for something else when observations vastly outnumber ensemble
+members without localization (cost), when $R$ is non-diagonal *and*
+huge (the solve dominates), or when you specifically want serial
+observation processing — `EnSRF_Serial`, chapter 7.
+
+## Where next
+
+- [Chapter 5 — Stochastic EnKF](05_stochastic_enkf.md): the
+  perturbed-observations alternative.
+- [Chapter 7 — EnSRF & ESTKF](07_ensrf_estkf.md): sibling square-root
+  filters; same transform, different phrasing and subspace.
+- [Chapter 8 — LETKF](08_letkf.md): one ETKF per grid point with
+  tapered $R^{-1}$.
+- [Chapter 14 — Differentiable assimilation](14_differentiable.md):
+  why gradient-safety of the analysis matters.
+- [API: Filters](../api/filters.md) ·
+  [API: Advanced filters](../api/filters_advanced.md) ·
+  [API: Differentiable](../api/differentiable.md)
+
+## References
+
+- Bishop, C. H., Etherton, B. J., & Majumdar, S. J. (2001). *Adaptive
+  sampling with the ensemble transform Kalman filter. Part I:
+  Theoretical aspects.* MWR 129(3).
+- Tippett, M. K., Anderson, J. L., Bishop, C. H., Hamill, T. M., &
+  Whitaker, J. S. (2003). *Ensemble square root filters.* MWR 131(7).
+- Livings, D. M., Dance, S. L., & Nichols, N. K. (2008). *Unbiased
+  ensemble square root filters.* Physica D 237(8).
+- Hunt, B. R., Kostelich, E. J., & Szunyogh, I. (2007). *Efficient data
+  assimilation for spatiotemporal chaos: A local ensemble transform
+  Kalman filter.* Physica D 230(1-2).

--- a/docs/math/07_ensrf_estkf.md
+++ b/docs/math/07_ensrf_estkf.md
@@ -1,0 +1,206 @@
+# EnSRF & ESTKF — Square-Root Variants
+
+The ETKF (chapter 6) is one member of a family: every *deterministic
+square-root filter* produces the exact Kalman analysis covariance
+$P_a = (I - KH)\,P$ on the sample statistics, without perturbed
+observations. The family members differ in **where** the square root is
+taken — observation space, ensemble space, or the error subspace — and
+in whether observations are processed in one batch or one at a time.
+This chapter covers the two variants filterax ships alongside ETKF:
+the EnSRF (batch and serial forms) and the ESTKF.
+
+## EnSRF — mean from the gain, perturbations from the transform
+
+Whitaker & Hamill (2002) phrase the square-root update in the most
+Kalman-familiar way possible. Split the ensemble into mean and
+anomalies and update them separately:
+
+$$
+\bar{x}_a = \bar{x} + K\, d, \qquad
+K = C^{xH} S^{-1}, \quad S = C^{HH} + R,
+$$
+
+with the perturbations transformed so that their sample covariance
+equals $(I - KH)\,P$ exactly. In filterax's batch `EnSRF` the
+perturbation half is the *symmetric ETKF transform* applied to the
+anomalies,
+
+$$
+X'_a = W X', \qquad W = \sqrt{(N_e - 1)\, \tilde{C}^{-1}},
+$$
+
+so the batch EnSRF and the ETKF are numerically the same filter — the
+symmetric square root is the unique PSD- and mean-preserving choice
+(chapter 6), and both classes share the differentiable QR + small-eigh
+core. The two classes coexist so you can use whichever phrasing is
+idiomatic in your community: "mean from $K$, perturbations from a
+square root" (EnSRF) versus "weights in ensemble space" (ETKF).
+
+## Serial processing — Whitaker & Hamill's scalar recursion
+
+The classical EnSRF distinction only appears when observations are
+assimilated **one at a time**. For a single scalar observation $y_k$
+with variance $R_{kk}$, the gain and innovation variance are scalars
+and no matrix inversion is needed at all. `EnSRF_Serial` sweeps over
+the observations with the recursion
+
+$$
+\begin{aligned}
+K_k &= C^{x H_k} \big/ \big(C^{H_k H_k} + R_{kk}\big) \\
+\bar{x}_a^{(k)} &= \bar{x}_a^{(k-1)}
+    + K_k \big(y_k - H_k \bar{x}_a^{(k-1)}\big) \\
+\alpha_k &= 1 \Big/ \Big(1 + \sqrt{R_{kk} \big/ \big(C^{H_k H_k} + R_{kk}\big)}\Big) \\
+X'^{(k)}_a &= X'^{(k-1)}_a - \alpha_k K_k \big(H_k X'^{(k-1)}_a\big)
+\end{aligned}
+$$
+
+where every quantity is recomputed from the *current* (partially
+updated) ensemble. The reduced gain $\alpha_k K_k$ is the scalar
+square-root trick: a full gain $K_k$ on the perturbations would shrink
+them twice over (once too much), and $\alpha_k \in (\tfrac12, 1)$ is
+exactly the factor that lands the anomaly variance on
+$(1 - K_k H_k)\,C^{xx}$. Each scalar update is an inner product, so the
+whole sweep costs $O(N_e N_x N_y)$ — no eigendecomposition anywhere.
+
+Requirements and trade-offs:
+
+- **Diagonal $R$ only.** Serial processing assumes uncorrelated
+  observation errors; assimilating one component of a correlated $y$
+  at a time is simply wrong. filterax raises `NotImplementedError` for
+  non-diagonal `obs_noise` — pre-decorrelate ($R^{-1/2} y$) or use the
+  batch filters.
+- **When serial beats batch.** The batch transform costs
+  $O(N_e^2 N_y + N_e^3)$; the serial sweep $O(N_e N_x N_y)$. With
+  large $N_e$ and cheap $\mathcal{H}$ the serial form wins; it also
+  pairs naturally with per-observation localization (each scalar update
+  can carry its own taper) and with streaming pipelines where
+  observations arrive incrementally.
+- **Order sensitivity.** In exact arithmetic with linear $H$ the result
+  is order-independent; with nonlinear $\mathcal{H}$ or per-observation
+  localization the assimilation order matters slightly. filterax
+  re-applies `obs_op` to the running ensemble inside every scalar step,
+  which keeps the sweep consistent for nonlinear $\mathcal{H}$ at the
+  cost of $N_y$ extra operator evaluations.
+
+## ESTKF — the error-subspace transform
+
+Nerger et al. (2012) observed that the ETKF's $N_e$-dimensional
+ensemble space is one dimension too big: anomalies always satisfy
+$X'^\top \mathbf{1} = 0$, so they span at most $N_e - 1$ directions.
+The ESTKF works directly in that error subspace. Choose a
+mean-preserving orthonormal map $L \in \mathbb{R}^{N_e \times (N_e-1)}$
+with $L^\top L = I$ and $L^\top \mathbf{1} = 0$ (filterax builds it
+from a Householder reflector), and project:
+
+$$
+\tilde{X} = L^{\top} X' \in \mathbb{R}^{(N_e-1) \times N_x}, \qquad
+\tilde{Y} = L^{\top} Y' \in \mathbb{R}^{(N_e-1) \times N_y}.
+$$
+
+Because $L$ spans exactly the anomaly subspace, nothing is lost. The
+transform precision is the $(N_e-1)$-dimensional analogue of
+$\tilde{C}$:
+
+$$
+A = (N_e - 1)\, I + \tilde{Y} R^{-1} \tilde{Y}^{\top}
+    \in \mathbb{R}^{(N_e-1) \times (N_e-1)},
+$$
+
+with weights and symmetric square root
+
+$$
+\tilde{w} = A^{-1} \tilde{Y} R^{-1} d, \qquad
+\tilde{W} = \sqrt{(N_e - 1)\, A^{-1}},
+$$
+
+lifted back to the full ensemble:
+
+$$
+\bar{x}_a = \bar{x} + \tilde{w}^{\top} \tilde{X}, \qquad
+X_a = \mathbf{1}\bar{x}_a^{\top} + L\, \tilde{W} \tilde{X}.
+$$
+
+The relation to ETKF: identical analysis mean and covariance, with the
+eigen-problem shrunk from $N_e^3$ to $(N_e-1)^3$ and the degenerate
+$\mathbf{1}$ direction removed *by construction* rather than handled as
+a known eigenvector. filterax's implementation reuses the same
+rank-$N_y$ QR + small-eigh spectrum as ETKF (the reduced anomalies
+$\tilde{Y}$ have the same rank-deficiency story), so gradients stay
+finite here too. ESTKF is the analysis core of the PDAF ecosystem, and
+matching it matters when cross-validating against PDAF-based
+experiments.
+
+## Implementation in filterax
+
+All filters share the `analysis(particles, obs, obs_op, obs_noise)`
+signature, so comparing them is a one-liner each:
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+
+import filterax as flx
+
+particles = jr.normal(jr.key(0), (25, 3))   # N_e = 25, N_x = 3
+obs = jnp.array([0.3, -0.2, 0.5])
+R = lx.DiagonalLinearOperator(0.2 * jnp.ones(3))
+obs_op = lambda x: x                        # identity observations
+
+etkf   = flx.filters.ETKF().analysis(particles, obs, obs_op, R)
+ensrf  = flx.filters.EnSRF().analysis(particles, obs, obs_op, R)
+serial = flx.filters.EnSRF_Serial().analysis(particles, obs, obs_op, R)
+estkf  = flx.filters.ESTKF().analysis(particles, obs, obs_op, R)
+
+mean = lambda r: r.particles.mean(axis=0)
+cov = lambda r: jnp.cov(r.particles.T, ddof=1)
+
+# All four produce the same analysis mean and covariance here
+# (linear H, diagonal R) — they differ only in how they get there.
+jnp.allclose(mean(ensrf),  mean(etkf), atol=1e-5)   # True
+jnp.allclose(mean(serial), mean(etkf), atol=1e-5)   # True
+jnp.allclose(mean(estkf),  mean(etkf), atol=1e-5)   # True
+jnp.allclose(cov(ensrf),   cov(etkf),  atol=1e-5)   # True
+jnp.allclose(cov(serial),  cov(etkf),  atol=1e-4)   # True
+jnp.allclose(cov(estkf),   cov(etkf),  atol=1e-5)   # True
+```
+
+The *individual members* are not identical across variants — each
+square root is a different rotation of the same analysis-covariance
+ellipsoid — but the first two sample moments agree, which is all the
+Kalman update specifies.
+
+## Choosing within the square-root family
+
+| Filter | Square root taken in | Cost | Use when |
+|---|---|---|---|
+| `ETKF` | ensemble space ($N_e$) | $O(N_e^2 N_y + N_e N_y^2)$ | Default deterministic filter |
+| `EnSRF` | ensemble space ($N_e$) | same as ETKF | You prefer the mean-from-$K$ phrasing |
+| `EnSRF_Serial` | observation space, scalar | $O(N_e N_x N_y)$ | Diagonal $R$, streaming obs, no eigh wanted |
+| `ESTKF` | error subspace ($N_e - 1$) | same as ETKF, smaller eigh | PDAF compatibility, exact subspace bookkeeping |
+| `ETKF_Livings` | ensemble space + rotation | ETKF + $O(N_e^3)$ | Long reanalyses where determinism breeds artefacts |
+
+All deterministic variants still need inflation (chapter 12) in cycled
+operation — removing sampling noise does not remove the systematic
+variance underestimation of a finite ensemble.
+
+## Where next
+
+- [Chapter 6 — ETKF](06_etkf.md): the transform mathematics and the
+  differentiability story shared by all of these filters.
+- [Chapter 8 — LETKF](08_letkf.md): the localized transform filter.
+- [Chapter 12 — Inflation](12_inflation.md): why square-root filters
+  still under-disperse in cycles.
+- [API: Filters](../api/filters.md) ·
+  [API: Advanced filters](../api/filters_advanced.md)
+
+## References
+
+- Whitaker, J. S., & Hamill, T. M. (2002). *Ensemble data assimilation
+  without perturbed observations.* MWR 130(7).
+- Tippett, M. K., Anderson, J. L., Bishop, C. H., Hamill, T. M., &
+  Whitaker, J. S. (2003). *Ensemble square root filters.* MWR 131(7).
+- Nerger, L., Janjić, T., Schröter, J., & Hiller, W. (2012). *A unification
+  of ensemble square root Kalman filters.* MWR 140(7).
+- Andrews, A. (1968). *A square root formulation of the Kalman
+  covariance equations.* AIAA Journal 6(6).

--- a/docs/math/08_letkf.md
+++ b/docs/math/08_letkf.md
@@ -1,0 +1,216 @@
+# LETKF — Local Ensemble Transform Kalman Filter
+
+A finite ensemble can only represent $N_e - 1$ directions of
+uncertainty, and its sample covariance $P = \frac{1}{N_e-1}X'^\top X'$
+is polluted by spurious long-range correlations: with $N_e = 50$
+members, the sample correlation between two physically unrelated grid
+points has standard deviation $\approx 1/\sqrt{N_e} \approx 0.14$ even
+when the true correlation is zero. A global analysis dutifully uses
+those phantom correlations to "correct" Antarctica with a thermometer
+in Berlin. Localization suppresses them by construction; the LETKF
+(Hunt, Kostelich & Szunyogh 2007) does it by *domain decomposition*:
+every grid point solves its own small ETKF using only nearby
+observations.
+
+## Domain localization with a tapered $R^{-1}$
+
+Attach coordinates to the state components ($N_x$ points
+$s_i \in \mathbb{R}^D$) and to the observations ($N_y$ points
+$o_k \in \mathbb{R}^D$). For grid point $i$:
+
+1. Compute distances $d_{ik} = \lVert s_i - o_k \rVert_2$ and taper
+   weights $\rho_{ik} = \rho(d_{ik}/r)$, by default the Gaspari-Cohn
+   fifth-order compactly supported function.
+2. Apply a **hard cutoff at $r$**: observations with $d_{ik} > r$ are
+   dropped entirely. (Gaspari-Cohn has support out to $2r$, so a purely
+   taper-based rule would let weakly tapered far observations leak in;
+   filterax enforces the documented selection radius exactly.)
+3. Inflate the surviving observation variances by $1/\rho_{ik}$ —
+   equivalently, taper the precision:
+
+$$
+\big[R^{-1}_{\mathrm{loc},i}\big]_{kk} = \frac{\rho_{ik}}{R_{kk}},
+\qquad \rho_{ik} = 0 \text{ for } d_{ik} > r .
+$$
+
+4. Solve the ETKF transform (chapter 6) with $R^{-1}$ replaced by
+   $R^{-1}_{\mathrm{loc},i}$ and write back only component $i$ of the
+   analysis.
+
+Down-weighting an observation by inflating its error variance is what
+"R-localization" means: distant data is treated as *less certain*
+rather than *less correlated*. As $\rho_{ik} \to 0$ the observation's
+precision contribution vanishes continuously, so the analysis varies
+smoothly from one grid point to the next — essential to avoid
+discontinuities in the analyzed fields. R-localization assumes a
+**diagonal $R$** (Hunt et al. 2007 §2); filterax accepts a
+`lineax.DiagonalLinearOperator` and rejects anything else.
+
+## The per-point weights formulation
+
+The decisive trick in Hunt et al. (2007) is that each local problem is
+solved *in ensemble space*, so its output is a pair of weight objects
+rather than a state:
+
+$$
+\tilde{C}_i = (N_e - 1)\, I + Y' R^{-1}_{\mathrm{loc},i} Y'^{\top},
+\qquad
+\bar{w}_i = \tilde{C}_i^{-1}\, Y' R^{-1}_{\mathrm{loc},i}\, d,
+\qquad
+W_i = \sqrt{(N_e - 1)\, \tilde{C}_i^{-1}} .
+$$
+
+The global anomaly matrices $X'$, $Y'$ and the innovation
+$d = y - \bar{y}$ are computed once; only the tapered precision changes
+per point. The analysis at grid point $i$ recombines the *global*
+anomalies with the *local* weights:
+
+$$
+\bar{x}_a[i] = \bar{x}[i] + \bar{w}_i^{\top} X'_{[:,i]}, \qquad
+X_a[j, i] = \bar{x}_a[i] + \big(W_i\, X'\big)_{[j, i]} .
+$$
+
+Each local solve is a complete, independent ETKF — $N_x$ of them, with
+no data dependencies. filterax `jax.vmap`s the per-point weight
+computation over `state_coords` and contracts all the weight matrices
+against the anomalies in two einsum calls. Each local transform uses
+the same differentiable QR + small-eigh spectrum as the global ETKF,
+so the localized analysis remains gradient-safe.
+
+## B-localization versus R-localization
+
+There are two places to cut off spurious correlations, and they are
+*not* the same operation:
+
+- **Covariance (B-)localization** (chapter 11) takes the Schur product
+  of the sample covariance with a taper matrix:
+  $P_{\mathrm{loc}} = \rho_B \circ P$. It acts in *state space*,
+  raises the rank of the effective covariance (a Schur product of PSD
+  matrices is PSD, and tapering restores degrees of freedom the
+  ensemble lacks), and slots naturally into gain-based filters
+  (`localized_kalman_gain`, the stochastic EnKF).
+- **Domain / R-localization** (this chapter) leaves $P$ untouched and
+  instead shrinks each grid point's *observation window*, tapering
+  $R^{-1}$ with distance. It acts in *observation space*, keeps every
+  local problem a dense low-dimensional ETKF, and is the natural fit
+  for transform filters, where the ensemble-space algebra never forms
+  $P$ at all.
+
+For broad tapers the two give similar analyses (Greybush et al. 2011
+compare them systematically; B-localization tends to produce slightly
+smoother, more balanced fields, R-localization is cheaper per
+observation in transform filters). The practical rule: gain-based
+filter → B-loc; transform filter → R-loc/LETKF.
+
+## Cost
+
+The global ETKF costs $O(N_e^2 N_y + N_e^3)$ once. The LETKF solves
+$N_x$ local problems of size $N_{y,\mathrm{loc}}$ (the typical number
+of observations within radius $r$):
+
+$$
+O\big(N_x \cdot (N_e^2 N_{y,\mathrm{loc}} + N_e^3)\big),
+$$
+
+linear in the state dimension with a small constant — and the $N_x$
+solves are embarrassingly parallel, which is exactly what `vmap` on an
+accelerator wants. This is why LETKF (and its ESTKF-core sibling in
+PDAF) is the workhorse of operational ensemble NWP: cost scales with
+the grid, not with the cube of the global observation count, and the
+localization simultaneously fixes the rank problem — each local
+analysis only needs the ensemble to resolve *local* error directions.
+
+The price: a localization radius to tune (too small starves the
+analysis of data and fragments balance; too large readmits sampling
+noise), and dynamical balances spanning scales longer than $r$ can be
+disrupted — diagnose with the tools of chapter 13.
+
+## Implementation in filterax
+
+`LETKF.analysis` needs two extra keyword arguments relative to the
+global filters: `state_coords` $(N_x, D)$ and `obs_coords` $(N_y, D)$.
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+
+import filterax as flx
+
+# 1-D grid of 8 state points, ensemble of 20 members.
+particles = jr.normal(jr.key(0), (20, 8))
+state_coords = jnp.arange(8.0)[:, None]          # (N_x, 1)
+
+# Observe grid points 1, 4 and 6.
+obs_idx = jnp.array([1, 4, 6])
+obs_coords = state_coords[obs_idx]               # (N_y, 1)
+obs = jnp.array([0.5, -0.3, 0.2])
+R = lx.DiagonalLinearOperator(0.25 * jnp.ones(3))
+
+letkf = flx.filters.LETKF(radius=2.0)            # Gaspari-Cohn taper by default
+result = letkf.analysis(
+    particles, obs, lambda x: x[obs_idx], R,
+    state_coords=state_coords, obs_coords=obs_coords,
+)
+result.particles.shape                           # (20, 8)
+
+# Compare the per-component update size against the global ETKF:
+global_result = flx.filters.ETKF().analysis(
+    particles, obs, lambda x: x[obs_idx], R
+)
+jnp.abs(result.particles - particles).mean(axis=0)
+# [0.028, 0.422, 0.014, 0.068, 0.404, 0.098, 0.536, 0.104]
+jnp.abs(global_result.particles - particles).mean(axis=0)
+# [0.180, 0.432, 0.029, 0.096, 0.404, 0.112, 0.541, 0.186]
+```
+
+Observed points (1, 4, 6) receive nearly the same correction in both;
+the far end-points (0, 7) are corrected by the global ETKF purely
+through sampling-noise correlations — the LETKF correction there is an
+order of magnitude smaller. A custom `taper_fn(distances, radius)` can
+replace Gaspari-Cohn (e.g. `flx.gaussian_taper`). The Layer-2
+`filterax.LETKF` model threads the coordinates through the
+`assimilate()` cycle for you.
+
+## When LETKF is the right answer
+
+- $N_x \gg N_e$ (any realistic geophysical grid) — the rank argument
+  alone forces localization.
+- Dense observation networks where a global transform would cost
+  $O(N_y^2)$ or worse.
+- States with meaningful spatial coordinates and roughly local error
+  correlations.
+
+It is the wrong tool for non-spatial state vectors (global parameters
+have no distance to observations — see chapter 9's inverse-problem
+methods), for strongly non-local observation operators (a satellite
+radiance integrating a whole column needs a definition of "location"
+per observation, usually the weighting-function peak), and for
+correlated $R$ (decorrelate first, or use the batch filters of
+chapters 6-7).
+
+## Where next
+
+- [Chapter 6 — ETKF](06_etkf.md): the transform solved at every grid
+  point.
+- [Chapter 11 — Localization](11_localization.md): B-localization,
+  taper functions, and adaptive radii.
+- [Chapter 12 — Inflation](12_inflation.md): LETKF in cycles still
+  needs spread maintenance.
+- [Chapter 13 — Diagnostics](13_diagnostics.md): innovation statistics
+  for tuning the radius.
+- [API: Filters](../api/filters.md) ·
+  [API: Localization](../api/localization.md)
+
+## References
+
+- Hunt, B. R., Kostelich, E. J., & Szunyogh, I. (2007). *Efficient data
+  assimilation for spatiotemporal chaos: A local ensemble transform
+  Kalman filter.* Physica D 230(1-2).
+- Ott, E., et al. (2004). *A local ensemble Kalman filter for
+  atmospheric data assimilation.* Tellus A 56(5).
+- Gaspari, G., & Cohn, S. E. (1999). *Construction of correlation
+  functions in two and three dimensions.* QJRMS 125(554).
+- Greybush, S. J., Kalnay, E., Miyoshi, T., Ide, K., & Hunt, B. R.
+  (2011). *Balance and ensemble Kalman filter localization techniques.*
+  MWR 139(2).

--- a/docs/math/09_ensemble_kalman_processes.md
+++ b/docs/math/09_ensemble_kalman_processes.md
@@ -1,0 +1,247 @@
+# Ensemble Kalman Processes — EKI, EKS, UKI
+
+The filters of chapters 5-8 track a *state* through time. The same
+ensemble-Kalman algebra also solves static **inverse problems**: given
+one batch of data
+
+$$
+y = G(\theta) + \eta, \qquad \eta \sim \mathcal{N}(0, \Gamma),
+$$
+
+estimate the parameters $\theta \in \mathbb{R}^{N_p}$ of a possibly
+expensive, possibly non-differentiable forward model
+$G: \mathbb{R}^{N_p} \to \mathbb{R}^{N_d}$. Iterate an ensemble of
+candidate parameters $\Theta \in \mathbb{R}^{J \times N_p}$ (rows are
+members, exactly as the filter chapters use $X$; the ensemble size $J$
+plays the role of $N_e$) and let the ensemble's own cross-covariances
+play the role of derivatives. No gradients of $G$ are ever required —
+which is the whole point.
+
+## EKI — a derivative-free Gauss-Newton flow
+
+Ensemble Kalman Inversion (Iglesias, Law & Stuart 2013) repeatedly
+applies a tempered Kalman update to the parameter ensemble. With
+forward evaluations $G^{(j)} = G(\theta^{(j)}_n)$, sample
+cross-covariance $C^{\theta G}_n$ and obs-space covariance $C^{GG}_n$:
+
+$$
+\theta^{(j)}_{n+1} = \theta^{(j)}_n + \Delta t_n\, C^{\theta G}_n
+    \big(C^{G G}_n + \Delta t_n^{-1} \Gamma\big)^{-1}
+    \big(y - G(\theta^{(j)}_n)\big).
+$$
+
+Why "Gauss-Newton-like"? Linearise $G$ and the increment becomes
+$C^{\theta\theta} \nabla G^\top (\cdots)^{-1} r$ — a least-squares
+Gauss-Newton step in which the ensemble statistics stand in for the
+Jacobian, preconditioned by the parameter covariance. The tempering
+$\Delta t^{-1} \Gamma$ makes $n$ steps of size $\Delta t$ with
+$\sum \Delta t_n = 1$ equivalent (in the linear-Gaussian limit) to
+*one* full Kalman update from the prior ensemble — the artificial time
+$t_n = \sum_{m \le n} \Delta t_m$ interpolates prior ($t = 0$) to
+posterior ($t = 1$). Two properties to internalise:
+
+- **Subspace property**: every iterate stays in the affine span of the
+  initial ensemble; EKI works even when $J < N_p$ (underdetermined).
+- **Ensemble collapse**: spread $\to 0$ as $t \to 1$. EKI is a point
+  estimator. The final spread is *not* posterior uncertainty.
+
+## EKS — Langevin sampling instead of collapse
+
+The Ensemble Kalman Sampler in its ALDI form (Garbuno-Inigo et al.
+2020) turns the flow into an interacting Langevin SDE whose stationary
+distribution is the posterior $p(\theta \mid y)$:
+
+$$
+\mathrm{d}\theta^{(j)} =
+    C^{\theta G} \Gamma^{-1} \big(y - G^{(j)}\big)\, \mathrm{d}t
+    \;-\; \frac{N_p + 1}{J} \big(\theta^{(j)} - \bar{\theta}\big)\, \mathrm{d}t
+    \;+\; \sqrt{2\, C^{\theta\theta}}\;\, \mathrm{d}W^{(j)} .
+$$
+
+The first term is the EKI drift; the $(N_p+1)/J$ correction removes
+finite-sample bias; the ensemble-preconditioned noise
+$\sqrt{2 C^{\theta\theta}}\,\mathrm{d}W$ keeps the spread alive — at
+stationarity the members are approximate posterior samples. filterax
+draws the noise in *ensemble space* using the factor
+$\sqrt{C^{\theta\theta}} = \Theta'^\top / \sqrt{J-1}$, so no dense
+$N_p \times N_p$ Cholesky is formed.
+
+## UKI — sigma points instead of an ensemble
+
+Unscented Kalman Inversion (Huang, Schneider & Stuart 2022) replaces
+the Monte Carlo ensemble with a parametric Gaussian belief
+$\theta \sim \mathcal{N}(\mu_n, \Sigma_n)$, probed by $2 N_p + 1$
+deterministic sigma points (Wan & van der Merwe 2000):
+
+$$
+\chi^0 = \mu, \qquad
+\chi^{\pm}_j = \mu \pm \sqrt{N_p + \lambda}\; [\sqrt{\Sigma}]_{:,j},
+\qquad \lambda = \alpha^2 (N_p + \kappa) - N_p,
+$$
+
+with quadrature weights $W_m^i, W_c^i$. The forward model is evaluated
+at every sigma point and the unscented statistics feed a tempered
+Kalman update on $(\mu, \Sigma)$:
+
+$$
+\mu_{n+1} = \mu_n + \Delta t\, C^{\theta y} S_n^{-1} (y - \hat{y}_0),
+\qquad
+\Sigma_{n+1} = \Sigma_n - \Delta t\, C^{\theta y} S_n^{-1} C^{\theta y \top}.
+$$
+
+Deterministic, reproducible, no collapse, and $\Sigma_n$ is calibrated
+in the linear-Gaussian case — at the price of $2 N_p + 1$ forward
+evaluations per step, which caps it at moderate $N_p \lesssim 100$.
+
+## Step-size schedulers
+
+Every process consumes a $\Delta t_n$ from an `AbstractScheduler`:
+
+- **`FixedScheduler(dt=...)`** — constant; you tune it. With
+  $\Delta t = 1$, one EKI/UKI step *is* the full Kalman update.
+- **`DataMisfitController`** (Iglesias 2016) — the standard adaptive
+  rule. With the ensemble-mean Mahalanobis misfit
+  $\Phi_n = J^{-1} \sum_j \lVert y - G(\theta^{(j)})\rVert^2_{\Gamma^{-1}}$,
+
+$$
+\Delta t_n = \min\big(\text{target\_misfit} / \Phi_n,\;
+    1 - t_n\big),
+$$
+
+  small careful steps while far from the data, ramping up as the misfit
+  falls, and clamped so the artificial time lands exactly on $t = 1$ —
+  the standard stopping rule. Past convergence it returns
+  $\Delta t = 0$ and further updates are no-ops, not NaNs.
+- **`EKSStableScheduler`** — bounds $\Delta t \le
+  \text{target}/\lVert C^{\theta\theta}\rVert$ (via a cheap Frobenius
+  bound) so the EKS Langevin discretisation stays in its stability
+  region.
+
+## The variant zoo, briefly
+
+| Process | One-line description |
+|---|---|
+| `processes.GNKI` | Explicit ensemble Jacobian $\tilde{J} = (C^{\theta\theta})^{-1} C^{\theta G}$ + Gauss-Newton step with prior pull-back; fast, needs $J > N_p$; recovers the exact linear-Gaussian posterior |
+| `processes.TEKI` | Tikhonov EKI: augments $\tilde{G}(\theta) = (G(\theta), \theta)$, $\tilde{y} = (y, m_0)$, $\tilde{\Gamma} = \mathrm{blockdiag}(\Gamma, \Sigma_0)$ — vanilla EKI on the augmented system converges to the MAP instead of drifting on ill-posed problems |
+| `processes.SparseInversion` | EKI step + L¹ soft-threshold prox $\mathrm{sign}(z)\max(|z| - \lambda, 0)$ — drives inactive parameters exactly to zero (variable selection) |
+| `processes.ETKI` | Transform-flavoured EKI; currently shares EKI's Woodbury-routed solve |
+
+## Three API layers
+
+filterax exposes the processes at three altitudes, all built on the
+same Layer-1 update rules:
+
+1. **Layer 1** (`filterax.processes.*`): `init(particles, obs,
+   noise_cov)` / `update(state, forward_evals)`. *You* evaluate
+   $G$ each step — full control over batching, checkpointing, or HPC
+   dispatch of the forward model.
+2. **Layer 2** (`filterax.EKI`, `filterax.EKS`, `filterax.UKI`): owns
+   the `init → vmap(G) → update` loop. `run(init_particles)` iterates
+   until `n_iterations` or `algo_time ≥ 1` and returns a
+   `ProcessResult` with mean, particles, and per-step history.
+3. **optax** (`filterax.optax.eki/eks/uki`): each process as an
+   `optax.GradientTransformation`. The ensemble lives in the opt
+   state, `params` carries the running mean, and the `grads` argument
+   is ignored — so derivative-free EKP steps compose with optax
+   schedules, clipping, and gradient-based warm-starts.
+
+## Implementation in filterax
+
+```python
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+
+import filterax as flx
+
+# Linear inverse problem: y = G theta + eta, theta_true = [1, -1].
+G = jnp.array([[1.0, 0.5], [-0.3, 1.2], [0.7, 0.1]])
+y = G @ jnp.array([1.0, -1.0])
+Gamma = lx.DiagonalLinearOperator(0.1 * jnp.ones(3))
+forward = lambda theta: G @ theta
+
+init = 2.0 * jr.normal(jr.key(0), (100, 2))      # J = 100 prior draws
+
+# Layer 2: forward model + process + scheduler in one .run().
+# FixedScheduler(dt=1.0) makes the first step a full Kalman update,
+# so algo_time hits 1 immediately and the loop stops.
+eki = flx.EKI(
+    forward_fn=forward, obs=y, noise_cov=Gamma,
+    scheduler=flx.FixedScheduler(dt=1.0),
+)
+result = eki.run(init)
+result.mean                       # [0.985, -0.985] — at the posterior mean
+bool(result.converged)            # True (algo_time reached 1)
+result.particles.std(axis=0)      # ~0.03 — collapsed: EKI is a point estimator
+
+# Layer 1: explicit loop — you own the forward evaluations.
+process = flx.processes.EKI(scheduler=flx.FixedScheduler(dt=1.0))
+state = process.init(init, y, Gamma)
+for _ in range(3):
+    evals = jax.vmap(forward)(state.particles)
+    state = process.update(state, evals)
+state.particles.mean(axis=0)      # [0.998, -0.998]
+```
+
+And the optax flavour — the same EKI driven through a standard optax
+update loop (with `grads=None`):
+
+```python
+import optax
+
+transform = flx.optax.eki(
+    forward_fn=forward, obs=y, noise_cov=Gamma,
+    n_ensemble=200, init_spread=5.0,
+    scheduler=flx.FixedScheduler(dt=1.0),
+)
+params = jnp.zeros(2)
+state = transform.init(params)
+for _ in range(3):
+    updates, state = transform.update(None, state, params)
+    params = optax.apply_updates(params, updates)
+params                            # [0.996, -0.998]
+```
+
+For real problems with expensive nonlinear $G$, swap in
+`flx.DataMisfitController()` and a larger iteration budget
+(`flx.ProcessConfig(n_iterations=...)`); the controller takes many
+small steps while the misfit is large and stops at the noise level.
+
+## Choosing a process
+
+Need posterior samples → **EKS**. Need a calibrated parametric
+covariance and $N_p \lesssim 100$ → **UKI**. Sparse parameters →
+**SparseInversion**. Ill-posed, drifting EKI → **TEKI**.
+Well-conditioned with $J > N_p$ and a hurry → **GNKI**. Otherwise →
+**EKI**, the simple robust default.
+
+## Where next
+
+- [Chapter 4 — Kalman update & ensemble gain](04_kalman_update.md):
+  the cross-covariance algebra reused here.
+- [Chapter 10 — Ensemble smoothers](10_smoothers.md): IES, the
+  closely-related iterative smoother for time-series inverse problems.
+- [API: Processes](../api/processes.md) ·
+  [API: Schedulers](../api/schedulers.md) ·
+  [API: optax integration](../api/optax.md)
+
+## References
+
+- Iglesias, M. A., Law, K. J. H., & Stuart, A. M. (2013). *Ensemble
+  Kalman methods for inverse problems.* Inverse Problems 29(4).
+- Iglesias, M. A. (2016). *A regularizing iterative ensemble Kalman
+  method for PDE-constrained inverse problems.* Inverse Problems 32(2).
+- Schillings, C., & Stuart, A. M. (2017). *Analysis of the ensemble
+  Kalman filter for inverse problems.* SIAM J. Numer. Anal. 55(3).
+- Garbuno-Inigo, A., Nüsken, N., & Reich, S. (2020). *Affine invariant
+  interacting Langevin dynamics for Bayesian inference.* SIAM J. Appl.
+  Dyn. Syst. 19(3).
+- Huang, D. Z., Schneider, T., & Stuart, A. M. (2022). *Iterated Kalman
+  methodology for inverse problems.* J. Comput. Phys. 463.
+- Chada, N. K., Stuart, A. M., & Tong, X. T. (2019). *Tikhonov
+  regularization within ensemble Kalman inversion.* SIAM J. Numer.
+  Anal. 58(2).
+- Schneider, T., Stuart, A. M., & Wu, J.-L. (2022). *Ensemble Kalman
+  inversion for sparse learning of dynamical systems from
+  time-averaged data.* J. Comput. Phys. 470.

--- a/docs/math/10_smoothers.md
+++ b/docs/math/10_smoothers.md
@@ -1,0 +1,243 @@
+# Ensemble Smoothers
+
+A filter is causal: the analysis at time $t$ conditions on observations
+up to $t$ only, approximating the **filtering density**
+$p(x_t \mid y_{1:t})$. For reanalysis, parameter estimation, or any
+retrospective study, the right object is the **smoothing density**
+
+$$
+p(x_t \mid y_{1:T}), \qquad t < T,
+$$
+
+which also lets observations *after* $t$ inform the estimate. A
+smoother never makes the estimate worse in expectation — it conditions
+on strictly more data — and the gain is largest mid-trajectory, where
+plenty of future observations exist. Ensemble smoothers obtain it
+cheaply: run the filter forward once, store its history, then sweep
+backward, recombining stored ensembles. No adjoint model, no extra
+forward-model runs.
+
+## EnKS — forward filter, backward gain recursion
+
+Let $X^a_t$ and $X^f_{t+1}$ be the stored analysis and forecast
+ensembles (the forecast at $t{+}1$ is the propagation of the analysis
+at $t$), with anomaly matrices $A_t$ and $F_{t+1}$ (rows are members,
+as everywhere). The Ensemble Kalman Smoother (Evensen & van Leeuwen
+2000) initialises $X^s_{T-1} = X^a_{T-1}$ and recurses backward with
+the **smoother gain**
+
+$$
+G_t = \underbrace{\tfrac{1}{N_e-1} A_t^{\top} F_{t+1}}_{C^{af}_{t,t+1}}
+      \;\Big(\underbrace{\tfrac{1}{N_e-1} F_{t+1}^{\top} F_{t+1}}_{C^{ff}_{t+1}}\Big)^{+},
+$$
+
+applied per member:
+
+$$
+X^s_t[j] = X^a_t[j] + \Big(G_t \big(X^s_{t+1}[j] - X^f_{t+1}[j]\big)^\top\Big)^\top .
+$$
+
+Read it as the Kalman update with the "observation" being the future:
+the cross-covariance $C^{af}$ says how analysis errors at $t$
+correlate with forecast errors at $t{+}1$, and the discrepancy
+$X^s_{t+1} - X^f_{t+1}$ — what smoothing changed about the future — is
+pulled back through it. The forecast covariance has rank
+$\le N_e - 1$, so the inverse is Moore-Penrose; filterax computes it
+through the $N_e \times N_e$ Gram matrix $F F^\top$ (never the
+$N_x \times N_x$ covariance), giving $O\!\big(T (N_e^2 N_x + N_e^3)\big)$
+for the entire backward pass. The whole sweep is a reversed
+`jax.lax.scan` — JIT-compatible and differentiable.
+
+## Ensemble RTS
+
+The classical Rauch-Tung-Striebel smoother is the same backward
+recursion phrased with the model's transition matrix:
+$G_t = P^a_t M_t^\top (P^f_{t+1})^{-1}$. In the ensemble version the
+cross-covariance $C^{af}_{t,t+1}$ *is* the sample estimate of
+$P^a_t M_t^\top$ — the propagated members carry the linearised dynamics
+implicitly — so for zero model error `EnsembleRTS` coincides with
+`EnKS` (Evensen 2003 §5). filterax ships both names sharing one
+implementation, so code can say which interpretation it means.
+
+## The square-root smoother
+
+`EnKS` applies a raw per-member correction, the backward analogue of
+the stochastic update. `EnsembleSqrtSmoother` (Whitaker & Compo 2002;
+Tippett et al. 2003) is the backward analogue of the *deterministic*
+filters of chapters 6-7: the smoothed mean is updated exactly as in
+EnKS, while the anomalies are transformed through a symmetric square
+root in ensemble space,
+
+$$
+\Lambda = I + K_e \big(D^{\top} D - F^{\top} F\big) K_e^{\top},
+\qquad K_e = (F F^{\top})^{+} F, \qquad
+A^s_t = \Lambda^{1/2} A_t,
+$$
+
+where $D$ holds the smoothed anomalies from $t+1$. Same complexity,
+same mean as EnKS; the perturbations differ only by an ensemble-space
+rotation, and the symmetric choice avoids accumulating cross-member
+coupling over many backward steps — the same argument that selects the
+symmetric square root in the ETKF. Pair it with a square-root forward
+filter (ETKF, EnSRF, ESTKF).
+
+## Fixed-lag smoothing
+
+The full EnKS needs the entire $T$-window history in memory and lets
+arbitrarily old states feel arbitrarily new data. `FixedLagSmoother`
+restricts the backward pass at anchor $s$ to the window
+$[s,\, \min(T{-}1,\, s + L)]$:
+
+- $L = 0$ reproduces the filter; $L \ge T - 1$ reproduces the EnKS.
+- Batch cost $O\!\big(T \cdot L \cdot (N_e^2 N_x + N_e^3)\big)$;
+  in a streaming setting only $L{+}1$ ensembles are held, states older
+  than the lag are finalised and dropped.
+
+The benefit saturates quickly: the correlation
+$C^{af}_{t,t+\ell}$ decays with lead $\ell$ at the decorrelation rate
+of the dynamics (fast, for chaotic systems), so a lag of a few
+decorrelation times captures nearly all of the smoothing gain at a
+fraction of the memory. Beyond that, sampled long-range correlations
+are mostly noise — a long lag can even *degrade* a small ensemble,
+which is localization-in-time by the same logic as chapter 8.
+
+## IES — Gauss-Newton in ensemble space
+
+The smoothers above refine a sequential filter's history. The
+**Iterative Ensemble Smoother** (Chen & Oliver 2013; Evensen et al.
+2019) attacks a single window head-on as an inverse problem
+$y = G(\theta) + \eta$, where $G$ maps parameters (or an initial
+state) to the whole observation record. Each iteration re-targets the
+*initial* ensemble plus a Kalman correction evaluated at the current
+iterate:
+
+$$
+\theta_{i+1}^{(j)} = (1 - \alpha)\, \theta_i^{(j)} + \alpha \Big[\theta_0^{(j)}
+    + K_i \big(y + \epsilon^{(j)} - G(\theta_i^{(j)})\big)\Big], \qquad
+K_i = C^{\theta G}_i \big(C^{GG}_i + \Gamma\big)^{-1},
+$$
+
+with perturbations $\epsilon^{(j)} \sim \mathcal{N}(0, \Gamma)$ redrawn
+per iteration. This is a Gauss-Newton iteration for the regularised
+least-squares problem, with the ensemble statistics standing in for the
+Jacobian (compare EKI in chapter 9 — the anchor to $\theta_0^{(j)}$,
+rather than a drift from the current iterate, is the distinguishing
+feature, and it is what keeps the prior in the objective). $\alpha = 1$
+is the pure Chen-Oliver update; $\alpha < 1$ damps it,
+Levenberg-Marquardt style, for strongly nonlinear $G$. One iteration
+on a linear $G$ reduces IES to the (ensemble) smoother update —
+that's `test_ies_single_step_matches_numpy_reference`. Its home turf
+is history matching and reservoir-type problems where one backward
+pass over a sequential filter is not enough.
+
+## Implementation in filterax
+
+All backward smoothers consume the stacked
+`forecast_history` / `analysis_history` $(T, N_e, N_x)$ produced by a
+Layer-2 filter's `assimilate()`:
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+
+import filterax as flx
+
+
+class Identity(flx.AbstractDynamics):
+    def __call__(self, state, t0, t1):
+        return state
+
+
+class ObserveFirstTwo(flx.AbstractObsOperator):
+    def __call__(self, state):
+        return state[:2]
+
+
+# Forward pass: 4 assimilation windows of an ETKF.
+particles = jr.normal(jr.key(0), (30, 4))
+R = lx.DiagonalLinearOperator(0.2 * jnp.ones(2))
+obs_seq = [
+    (jnp.array([0.5, -0.5]), 1.0),
+    (jnp.array([0.6, -0.4]), 2.0),
+    (jnp.array([0.4, -0.6]), 3.0),
+    (jnp.array([0.5, -0.5]), 4.0),
+]
+filt = flx.ETKF(dynamics=Identity(), obs_op=ObserveFirstTwo())
+history = filt.assimilate(particles, obs_seq, R)
+
+# Backward pass: refine the history into the smoothing density.
+smoothed = flx.smoothers.EnKS().smooth(
+    history.forecast_history, history.analysis_history
+)
+smoothed.smoothed_history.shape          # (4, 30, 4)
+
+# Final time untouched (no future data there) …
+jnp.allclose(smoothed.smoothed_history[-1], history.analysis_history[-1])  # True
+# … and earlier times tighten: mean spread at t=0 drops 0.674 → 0.581.
+history.analysis_history[0].std(axis=0, ddof=1).mean()
+smoothed.smoothed_history[0].std(axis=0, ddof=1).mean()
+
+# Bounded-memory variant: only look 2 windows ahead.
+flx.smoothers.FixedLagSmoother(lag=2).smooth(
+    history.forecast_history, history.analysis_history
+)
+
+# IES: a single-window inverse problem, iterated.
+G = jnp.array([[1.0, 0.5], [-0.3, 1.2], [0.7, 0.1]])
+y = G @ jnp.array([1.0, -1.0])
+Gamma = lx.DiagonalLinearOperator(0.1 * jnp.ones(3))
+init = 2.0 * jr.normal(jr.key(1), (50, 2))
+ies = flx.smoothers.IES(n_iterations=5, step_size=1.0)
+out = ies.solve(init, y, Gamma, lambda theta: G @ theta)
+out.particles.mean(axis=0)               # ≈ [0.98, -0.87] → toward [1, -1]
+```
+
+`SmoothingResult.particles` is the terminal ensemble
+(`smoothed_history[-1]`), matching the `AssimilationResult.particles`
+convention so a smoother output chains into a follow-up forecast. The
+backward pass works with *any* `AbstractSequentialFilter` history and
+is JIT- and `grad`-compatible (chapter 14).
+
+## Choosing a smoother
+
+| Smoother | Use when |
+|---|---|
+| `EnKS` | Default reanalysis: one backward pass over a stored filter history |
+| `EnsembleRTS` | Same algorithm; use the name when the RTS interpretation matters |
+| `EnsembleSqrtSmoother` | Paired with a deterministic forward filter; long backward chains |
+| `FixedLagSmoother` | Streaming / bounded memory; lag of a few decorrelation times |
+| `IES` | Strongly nonlinear single-window inverse problems (history matching) |
+
+## Where next
+
+- [Chapter 6 — ETKF](06_etkf.md): the forward square-root transform
+  the sqrt smoother mirrors.
+- [Chapter 9 — Ensemble Kalman processes](09_ensemble_kalman_processes.md):
+  EKI/EKS — IES's iterative siblings for parameter estimation.
+- [Chapter 14 — Differentiable assimilation](14_differentiable.md):
+  backpropagating through filter + smoother chains.
+- [Chapter 16 — The assimilation cycle](16_assimilation_cycle.md):
+  where `forecast_history` / `analysis_history` come from.
+- [API: Smoothers](../api/smoothers.md) ·
+  [API: Filters](../api/filters.md)
+
+## References
+
+- Evensen, G., & van Leeuwen, P. J. (2000). *An ensemble Kalman
+  smoother for nonlinear dynamics.* MWR 128(6).
+- Evensen, G. (2003). *The Ensemble Kalman Filter: theoretical
+  formulation and practical implementation.* Ocean Dynamics 53(4).
+- Whitaker, J. S., & Compo, G. P. (2002). *An ensemble Kalman smoother
+  for reanalysis.* Proc. Symp. on Observations, Data Assimilation and
+  Probabilistic Prediction.
+- Cosme, E., Verron, J., Brasseur, P., Blum, J., & Auroux, D. (2012).
+  *Smoothing problems in a Bayesian framework and their linear Gaussian
+  solutions.* MWR 140(2).
+- Chen, Y., & Oliver, D. S. (2013). *Levenberg-Marquardt forms of the
+  iterative ensemble smoother for efficient history matching and
+  uncertainty quantification.* Computational Geosciences 17(4).
+- Evensen, G., Raanes, P. N., Stordal, A. S., & Hove, J. (2019).
+  *Efficient implementation of an iterative ensemble smoother for
+  data assimilation and reservoir history matching.* Frontiers in
+  Applied Mathematics and Statistics 5.

--- a/docs/math/11_localization.md
+++ b/docs/math/11_localization.md
@@ -1,0 +1,251 @@
+# Localization
+
+A finite ensemble pays for its cheapness with sampling noise. The
+sample covariance $P = \frac{1}{N_e-1} X'^\top X'$ built from $N_e$
+members has rank at most $N_e - 1$, and — more damaging in practice —
+its entries between physically *unrelated* variables are not zero but
+random, with magnitude of order $1/\sqrt{N_e}$. A 20-member ensemble
+over a global grid will report correlations of $\sim 0.2$ between a
+grid point in the North Atlantic and one over Australia. The Kalman
+gain takes those correlations at face value and spreads every
+observation's increment across the entire domain. Over repeated
+cycles the accumulated noise overwhelms the signal and the filter
+diverges.
+
+Localization is the standard cure: damp covariance entries as a
+function of the physical distance $d_{ij}$ between variables $i$ and
+$j$, on the prior knowledge that physical correlations decay with
+distance while sampling noise does not.
+
+## The Schur product
+
+The localized covariance is the Schur (Hadamard, element-wise)
+product of the sample covariance with a taper matrix $\rho$:
+
+$$
+P_{\text{loc}} = \rho \circ P,
+\qquad
+\rho_{ij} = \rho(d_{ij} / r),
+$$
+
+where $r$ is the localization **half-width** (filterax's convention:
+compactly supported tapers vanish at distance $2r$). The crucial
+structural fact is the **Schur product theorem**: the element-wise
+product of two positive semi-definite matrices is positive
+semi-definite. So as long as the taper matrix $\rho$ is itself a
+valid correlation matrix — i.e. the taper function is positive
+definite — localization can *never* break the PSD-ness of the
+covariance, no matter how aggressively it cuts.
+
+That condition is what separates the taper functions below.
+
+## Taper functions
+
+### Gaspari-Cohn
+
+The operational gold standard ([Gaspari & Cohn 1999][gc99]). With
+$z = d / r$, the 5th-order piecewise polynomial is
+
+$$
+\rho(z) = \begin{cases}
+  -\tfrac14 z^5 + \tfrac12 z^4 + \tfrac58 z^3 - \tfrac53 z^2 + 1
+    & 0 \le z \le 1, \\[4pt]
+  \tfrac1{12} z^5 - \tfrac12 z^4 + \tfrac58 z^3 + \tfrac53 z^2
+    - 5 z + 4 - \dfrac{2}{3 z}
+    & 1 < z \le 2, \\[4pt]
+  0 & z > 2.
+\end{cases}
+$$
+
+[gc99]: references.md
+
+It has **compact support** (exactly zero beyond $d = 2r$, so distant
+blocks drop out of the linear algebra entirely), is **$C^2$ smooth**
+(value, first, and second derivatives match at $z = 1$ and $z = 2$),
+and is **positive definite** — it was constructed by self-convolving
+a compactly supported kernel precisely so the Schur product theorem
+applies. It closely mimics a Gaussian over its support.
+
+### Gaussian
+
+$$
+\rho(d) = \exp\!\left( -\frac{d^2}{2 r^2} \right).
+$$
+
+Infinitely smooth and positive definite, but **not** compactly
+supported — it decays exponentially yet never reaches zero, so no
+sparsity is gained. Useful when compact support is not needed (e.g.
+adjoint sensitivity studies where smoothness of $\partial \rho /
+\partial r$ matters more than cost).
+
+### SOAR
+
+The Second-Order Auto-Regressive taper (Thiebaux & Pedder 1987):
+
+$$
+\rho(d) = \left( 1 + \frac{d}{r} \right) e^{-d / r}.
+$$
+
+Positive definite and $C^1$ (one derivative fewer than Gaspari-Cohn),
+with *approximate* compact support — it falls below $0.01$ by
+$d \approx 5r$. A common correlation model for background errors in
+operational variational systems; as a localization taper it is a
+simpler alternative when strict compact support is not required.
+
+### Hard cutoff
+
+$$
+\rho(d) = \mathbb{1}\{ d \le r \}.
+$$
+
+Discontinuous, and — the important part — **not positive definite**
+in general. The Schur product theorem does not apply, the localized
+matrix can acquire negative eigenvalues, and the filter can go
+unstable in ways that are hard to diagnose. filterax ships it as a
+debugging baseline only; use Gaspari-Cohn or SOAR in production.
+
+## Distances and the taper matrix
+
+Building $\rho$ means evaluating the taper on a pairwise distance
+matrix. `filterax.localization_matrix(coords_a, coords_b, radius)`
+fuses the two steps, delegating to `gaussx.localization_matrix` with
+the compact-support parameter $c = 2r$ (gaussx parameterises by the
+support length, filterax by the half-width — the entries agree
+exactly with `gaspari_cohn(metric(a, b), r)`). The default metric is
+`euclidean_distance`; pass `haversine_distance` for (lat, lon)
+coordinates in radians on the sphere. Both are re-exported from
+gaussx unchanged.
+
+## The localized Kalman gain
+
+Tapering $P$ propagates into the gain. With $\rho^{xy}$ the
+state–observation taper and $\rho^{yy}$ the observation–observation
+taper,
+
+$$
+K_{\text{loc}}
+  = \big(\rho^{xy} \circ C^{xH}\big)
+    \big(\rho^{yy} \circ C^{HH} + R\big)^{-1},
+$$
+
+which is **B-localization**: the taper acts on the background
+covariance, evaluated between physical coordinates. By the Schur
+product theorem the tapered innovation covariance stays PSD whenever
+$\rho^{yy}$ is. With $\rho \equiv 1$ this reduces exactly to the
+unlocalized gain of chapter 4.
+
+There is a real cost. The unlocalized gain keeps $S = C^{HH} + R$ as
+a rank-$(N_e-1)$ update of $R$ and solves it through the Woodbury
+identity at $O(N_e^2 N_y + N_e^3)$. The Hadamard product **destroys
+that low-rank structure** — $\rho^{yy} \circ C^{HH}$ is generically
+full-rank — so `localized_kalman_gain` materialises the dense
+$(N_y, N_y)$ innovation covariance and pays $O(N_e N_x N_y + N_y^3)$.
+This is the algebraic reason the LETKF (chapter 8) prefers
+**R-localization**: instead of tapering covariances, it solves a
+small local analysis at each grid point with distant observations'
+errors inflated by $1/\rho$, keeping every local solve cheap. B-loc
+(this chapter) is the natural fit for gain-based filters
+(`StochasticEnKF`, serial EnSRF); R-loc for transform filters.
+
+## Adaptive localization
+
+Distance-based tapers need a radius, and the right radius depends on
+the (unknown) true correlation structure. Anderson's hierarchical
+argument ([Anderson 2007][a07]) suggests a *data-driven* alternative:
+keep a gain entry only when its sample correlation exceeds its own
+sampling uncertainty. For each (state $i$, observation $j$) pair with
+sample correlation $r_{ij} = C^{xH}_{ij} / (\sigma_{x_i}
+\sigma_{y_j})$, the noise floor is
+
+$$
+\operatorname{se}(r) \approx \frac{1 - r^2}{\sqrt{N_e - 2}},
+$$
+
+[a07]: references.md
+
+and `adaptive_localization` returns the hard mask
+$\rho_{ij} = \mathbb{1}\{ |r_{ij}| > \text{significance} \cdot
+\operatorname{se}(r_{ij}) \}$, multiplied into the gain as a Schur
+product. No radius to tune — but it needs enough members for the
+noise floor to be informative (typically $N_e \ge 20$, and $N_e \ge 3$
+is enforced) and costs an extra $O(N_e N_x N_y)$ per cycle.
+
+## Implementation in filterax
+
+```python
+import jax
+import jax.numpy as jnp
+import lineax as lx
+
+import filterax as flx
+
+# A 40-point 1-D grid observed at every 4th point.
+N_x, N_e = 40, 10
+grid = jnp.arange(N_x, dtype=jnp.float32)[:, None]
+obs_idx = jnp.arange(0, N_x, 4)
+obs_coords = grid[obs_idx]
+
+# Small ensemble -> noisy sample covariance with spurious long-range entries.
+key = jax.random.key(0)
+ensemble = jax.random.normal(key, (N_e, N_x))
+anom = ensemble - ensemble.mean(axis=0)
+P = anom.T @ anom / (N_e - 1)
+
+# Taper and localize: P_loc = rho ∘ P.
+rho = flx.localization_matrix(grid, grid, radius=3.0)
+P_loc = flx.localize(P, rho)
+
+far = jnp.abs(grid[:, 0, None] - grid[None, :, 0]) > 6.0
+print("max |P|     at d > 2r:", float(jnp.abs(P)[far].max()))
+print("max |P_loc| at d > 2r:", float(jnp.abs(P_loc)[far].max()))
+
+# Localized gain: taper both the cross- and obs-space covariances.
+obs_particles = ensemble[:, obs_idx]
+R = lx.DiagonalLinearOperator(0.25 * jnp.ones(obs_idx.shape[0]))
+rho_xy = flx.localization_matrix(grid, obs_coords, radius=3.0)
+rho_yy = flx.localization_matrix(obs_coords, obs_coords, radius=3.0)
+K_loc = flx.localized_kalman_gain(ensemble, obs_particles, R, rho_xy, rho_yy)
+print("K_loc shape:", K_loc.shape)
+```
+
+```
+max |P|     at d > 2r: 1.0718183517456055
+max |P_loc| at d > 2r: 0.0
+K_loc shape: (40, 10)
+```
+
+The raw sample covariance carries $O(1)$ spurious entries between
+points more than $2r$ apart; after the Gaspari-Cohn Schur product
+they are identically zero, and the gain pulls each state point only
+toward nearby observations.
+
+## Where next
+
+- [Chapter 4 — Kalman update & ensemble gain](04_kalman_update.md):
+  the unlocalized gain this chapter tapers.
+- [Chapter 8 — LETKF](08_letkf.md): R-localization — the
+  transform-filter alternative to the B-localization shown here.
+- [Chapter 12 — Inflation](12_inflation.md): localization's companion
+  fix; localization itself contributes to spread deficits that
+  inflation must repair.
+- [API: Localization](../api/localization.md) — `gaspari_cohn`,
+  `gaussian_taper`, `soar_taper`, `hard_cutoff`,
+  `localization_matrix`, `localize`, `localized_kalman_gain`,
+  `adaptive_localization`.
+
+## References
+
+- Gaspari, G. & Cohn, S. E. (1999). *Construction of correlation
+  functions in two and three dimensions.* Q. J. R. Meteorol. Soc.,
+  125, 723–757.
+- Houtekamer, P. L. & Mitchell, H. L. (2001). *A sequential ensemble
+  Kalman filter for atmospheric data assimilation.* Mon. Wea. Rev.,
+  129, 123–137.
+- Anderson, J. L. (2007). *Exploring the need for localization in
+  ensemble data assimilation using a hierarchical ensemble filter.*
+  Physica D, 230, 99–111.
+- Thiebaux, H. J. & Pedder, M. A. (1987). *Spatial Objective
+  Analysis.* Academic Press.
+- Hunt, B. R., Kostelich, E. J., & Szunyogh, I. (2007). *Efficient
+  data assimilation for spatiotemporal chaos: A local ensemble
+  transform Kalman filter.* Physica D, 230, 112–126.

--- a/docs/math/12_inflation.md
+++ b/docs/math/12_inflation.md
@@ -1,0 +1,282 @@
+# Inflation
+
+Every finite-ensemble Kalman filter systematically *underestimates*
+its own uncertainty. Three effects compound:
+
+1. **Finite $N_e$.** The analysis contracts the ensemble using a gain
+   computed from the ensemble's own sampled covariance, and the
+   sampling error preferentially over-contracts — the filter "trusts"
+   noise modes it has just fit.
+2. **Model error.** Members propagate through an imperfect model with
+   no representation of the model's own error, so the forecast spread
+   misses an entire error source.
+3. **Localization side-effects.** Tapering (chapter 11) distorts
+   analysis increments away from the optimal-gain geometry, which
+   also removes variance.
+
+Left untreated, the spread collapses over cycles, the gain
+$K = C^{xH}(C^{HH}+R)^{-1} \to 0$, and the filter stops listening to
+observations entirely — **filter divergence**: the forecast drifts
+with the model while reporting near-zero uncertainty.
+
+Inflation is the deliberate re-injection of spread. filterax ships
+the classic trio (multiplicative, RTPS, RTPP — pure functions
+delegating to the gaussx ensemble-DA primitives) plus three
+filterax-specific advanced primitives (additive, adaptive,
+Ledoit-Wolf).
+
+## Multiplicative inflation
+
+The simplest fix (Anderson & Anderson 1999): scale the anomalies
+about the mean,
+
+$$
+x^{(j)} \leftarrow \bar{x} + \lambda \big( x^{(j)} - \bar{x} \big),
+\qquad\text{i.e.}\qquad
+X' \leftarrow \lambda X',
+$$
+
+so the covariance becomes $\lambda^2 P$ while the mean is untouched.
+Typical operational values are $\lambda \in [1.01, 1.10]$. One knob,
+applied uniformly — which is also its weakness: regions that are
+densely observed (and genuinely contracted by data) get the same
+boost as regions where the spread was already healthy.
+
+## Relaxation methods: RTPS and RTPP
+
+Relaxation methods are smarter: instead of inflating blindly, they
+*relax the analysis back toward the forecast*, so the correction is
+automatically largest exactly where the analysis contracted most.
+
+**RTPS** — Relaxation to Prior **Spread** (Whitaker & Hamill 2012) —
+works per variable on standard deviations. The target spread is a
+convex blend of analysis and forecast spread,
+
+$$
+\sigma^{\text{target}}_i
+  = (1 - \alpha)\, \sigma^a_i + \alpha\, \sigma^f_i,
+$$
+
+and each analysis anomaly is rescaled to hit it:
+
+$$
+x^{(j)}_{\text{relaxed}}
+  = \bar{x}^a
+  + \frac{\sigma^{\text{target}}_i}{\sigma^a_i}
+    \big( x^{(j)}_a - \bar{x}^a \big).
+$$
+
+$\alpha = 0$ is the identity; $\alpha = 1$ restores the full forecast
+spread. Because the factor is per-variable, RTPS is spatially
+adaptive for free. It rescales each variable's spread but leaves the
+analysis *correlation structure* intact.
+
+**RTPP** — Relaxation to Prior **Perturbations** (Zhang et al. 2004)
+— blends the anomaly matrices themselves:
+
+$$
+X'_{\text{relaxed}} = (1 - \alpha)\, X'_a + \alpha\, X'_f.
+$$
+
+Unlike RTPS, this mixes the *inter-variable correlation structure*
+of forecast and analysis, not just the marginal spreads — useful when
+the analysis update is suspected of damaging cross-correlations (e.g.
+under aggressive localization), at the price of partially undoing the
+correlation information the observations provided. Both are
+mean-preserving and parameterised by a single $\alpha \in [0, 1]$.
+
+## Additive inflation
+
+When the dominant model-error mode is *not represented in the
+ensemble at all* — structurally underdispersive in some subspace —
+multiplying the existing anomalies cannot help: $\lambda \cdot 0 = 0$.
+Additive inflation (Hamill & Whitaker 2005) injects noise with its
+own covariance:
+
+$$
+X' \leftarrow X' + \varepsilon,
+\qquad
+\varepsilon^{(j)} \sim \mathcal{N}(0, Q_{\text{add}}),
+$$
+
+with $Q_{\text{add}}$ typically built from climatological
+variability, lagged forecast differences, or stochastic-physics
+tendency variances. `inflate_additive` centres the drawn noise so the
+ensemble mean is exactly preserved, and a diagonal $Q_{\text{add}}$
+never materialises. It is the one *stochastic* primitive in the set —
+which matters for differentiable training (chapter 14).
+
+## Adaptive inflation
+
+Hand-tuning $\lambda$ is unsatisfying when the innovations themselves
+tell you whether the filter is over- or under-dispersive. Anderson's
+Bayesian scheme (Anderson 2009) treats $\lambda$ as a random
+variable with Gaussian prior $\lambda \sim \mathcal{N}(\mu_\lambda,
+\sigma^2_\lambda)$, updated each cycle by the normalised innovation.
+The data-implied factor is the clamped Mahalanobis ratio
+
+$$
+\hat{\lambda}_{\text{obs}} = \operatorname{clip}\!\left(
+    \frac{d^\top S^{-1} d}{N_y},\ \lambda_{\min},\ \lambda_{\max}
+\right)
+$$
+
+— under correct specification $E[\chi^2 / N_y] = 1$ (chapter 13);
+an underdispersive ensemble overshoots and pulls
+$\hat{\lambda}_{\text{obs}}$ above 1. The posterior is the Gaussian
+product of the prior with a likelihood centred at
+$\hat{\lambda}_{\text{obs}}$ whose variance is the $\chi^2$ variance
+$\sigma^2_{\text{obs}} = 2 / N_y$:
+
+$$
+\mu_{\text{post}} =
+    \frac{\sigma^2_\lambda\, \hat{\lambda}_{\text{obs}}
+          + \sigma^2_{\text{obs}}\, \mu_{\text{prior}}}
+         {\sigma^2_\lambda + \sigma^2_{\text{obs}}},
+\qquad
+\sigma^2_{\text{post}} =
+    \frac{\sigma^2_\lambda\, \sigma^2_{\text{obs}}}
+         {\sigma^2_\lambda + \sigma^2_{\text{obs}}}.
+$$
+
+`inflate_adaptive` returns $(\mu_{\text{post}},
+\sigma^2_{\text{post}})$ as JAX scalars, so the belief carries across
+windows through `jax.jit` / `lax.scan`; applying the inflation is one
+`inflate_multiplicative` call with $\mu_{\text{post}}$ as the factor.
+
+## Ledoit-Wolf shrinkage
+
+A different angle on the same disease: rather than inflating the
+*ensemble*, regularise the *covariance estimate*. Ledoit-Wolf
+shrinkage (Ledoit & Wolf 2004) replaces the sample covariance with a
+convex combination toward a scalar-identity target,
+
+$$
+P_{\text{shrunk}}
+  = (1 - \lambda^*)\, P_{\text{sample}} + \lambda^* \mu I,
+\qquad
+\mu = \frac{\operatorname{tr}(P_{\text{sample}})}{N_x},
+$$
+
+with the closed-form optimal intensity
+
+$$
+\lambda^* = \min\!\left( 1,\ \frac{b^2}{d^2} \right),
+\qquad
+d^2 = \lVert P_{\text{sample}} - \mu I \rVert_F^2,
+\qquad
+b^2 = \frac{1}{N_e^2} \sum_j
+    \lVert x^{(j)} x^{(j)\top} - P_{\text{sample}} \rVert_F^2,
+$$
+
+minimising $E\lVert P_{\text{shrunk}} - P_{\text{true}} \rVert_F^2$.
+The result is PSD and well-conditioned even when $N_e \ll N_x$, but
+dense $(N_x, N_x)$ — call it only when $N_x$ is small enough to
+materialise, e.g. parameter-space ensembles in EKI/EKS workflows
+(chapter 9).
+
+## Inflators in the L2 loop
+
+The pure functions above are wrapped as `AbstractInflator` modules —
+`MultiplicativeInflator`, `RTPS`, `RTPP`, `AdditiveInflator` — so an
+inflation policy is a configuration object. In every L2 model
+(`filterax.ETKF`, `LETKF`, …) the per-window loop is **forecast →
+analysis → inflate**: the inflator receives both the analysis and the
+forecast ensemble (so RTPS/RTPP can relax toward the prior), and its
+output seeds the next forecast. `AdditiveInflator` additionally folds
+the window index into its base PRNG key
+(`jr.fold_in(base_key, step)`) so successive windows draw independent
+perturbations; deterministic inflators ignore the kwarg.
+
+## Implementation in filterax
+
+```python
+import jax
+import jax.numpy as jnp
+
+import filterax as flx
+
+key = jax.random.key(0)
+N_e, N_x = 20, 8
+forecast = jax.random.normal(key, (N_e, N_x))
+analysis = forecast * 0.4  # an over-tightened analysis
+
+print("forecast spread:", float(flx.utils.rms_spread(forecast)))
+print("analysis spread:", float(flx.utils.rms_spread(analysis)))
+
+inflated = flx.inflate_multiplicative(analysis, 1.6)
+relaxed_s = flx.RTPS(alpha=0.5)(analysis, forecast)
+relaxed_p = flx.RTPP(alpha=0.5)(analysis, forecast)
+print("multiplicative:", float(flx.utils.rms_spread(inflated)))
+print("RTPS alpha=0.5:", float(flx.utils.rms_spread(relaxed_s)))
+print("RTPP alpha=0.5:", float(flx.utils.rms_spread(relaxed_p)))
+
+# Adaptive (Anderson 2009): carry (mu, sigma^2) across cycles.
+d = jnp.array([1.5, -1.2, 0.9])              # an over-confident cycle
+S = jnp.diag(jnp.array([0.5, 0.5, 0.5]))     # innovation covariance
+mu, var = flx.inflate_adaptive(1.0, 0.05, d, S, max_factor=1.5)
+print("posterior lambda:", float(mu), " var:", float(var))
+
+# Ledoit-Wolf shrinkage of an anisotropic sample covariance.
+scales = jnp.array([3.0, 2.0, 1.0, 0.5, 0.5, 0.3, 0.3, 0.2])
+ens = jax.random.normal(key, (N_e, N_x)) * scales
+P_shrunk, lam = flx.ledoit_wolf_shrinkage(ens)
+print("shrinkage intensity:", round(lam, 3))
+```
+
+```
+forecast spread: 0.9815067052841187
+analysis spread: 0.39260268211364746
+multiplicative: 0.6281642913818359
+RTPS alpha=0.5: 0.6870546936988831
+RTPP alpha=0.5: 0.6870546936988831
+posterior lambda: 1.034883737564087  var: 0.04651162773370743
+shrinkage intensity: 0.189
+```
+
+(RTPS and RTPP agree here because the analysis is an exact rescaling
+of the forecast — they differ only when the analysis has *reshaped*
+the anomalies, not just shrunk them.) The adaptive update nudges
+$\lambda$ from 1.0 toward the data-implied value, but only as far as
+the prior variance allows; the posterior variance shrinks for the
+next cycle.
+
+## Where next
+
+- [Chapter 11 — Localization](11_localization.md): the companion fix
+  for sampling noise — and one of the spread-collapse mechanisms
+  inflation must offset.
+- [Chapter 13 — Diagnostics & likelihood](13_diagnostics.md): the
+  $\chi^2$ and spread-skill statistics that tell you *whether* to
+  inflate, and that feed the adaptive update.
+- [Chapter 14 — Differentiable assimilation](14_differentiable.md):
+  why `AdditiveInflator` is rejected under `jax.grad` while the
+  deterministic trio passes through.
+- [Chapter 16 — The assimilation cycle](16_assimilation_cycle.md):
+  where inflation sits in the L2 forecast–analyse–inflate loop.
+- [API: Inflation](../api/inflation.md) — `inflate_multiplicative`,
+  `inflate_rtps`, `inflate_rtpp`, `inflate_additive`,
+  `inflate_adaptive`, `ledoit_wolf_shrinkage`, and the
+  `AbstractInflator` wrappers.
+
+## References
+
+- Anderson, J. L. & Anderson, S. L. (1999). *A Monte Carlo
+  implementation of the nonlinear filtering problem to produce
+  ensemble assimilations and forecasts.* Mon. Wea. Rev., 127,
+  2741–2758.
+- Zhang, F., Snyder, C., & Sun, J. (2004). *Impacts of initial
+  estimate and observation availability on convective-scale data
+  assimilation.* Mon. Wea. Rev., 132, 1238–1253.
+- Hamill, T. M. & Whitaker, J. S. (2005). *Accounting for the error
+  due to unresolved scales in ensemble data assimilation: A
+  comparison of different approaches.* Mon. Wea. Rev., 133,
+  3132–3147.
+- Whitaker, J. S. & Hamill, T. M. (2012). *Evaluating methods to
+  account for system errors in ensemble data assimilation.* Mon.
+  Wea. Rev., 140, 3078–3089.
+- Anderson, J. L. (2009). *Spatially and temporally varying adaptive
+  covariance inflation for ensemble filters.* Tellus A, 61, 72–83.
+- Ledoit, O. & Wolf, M. (2004). *A well-conditioned estimator for
+  large-dimensional covariance matrices.* J. Multivariate Anal., 88,
+  365–411.

--- a/docs/math/13_diagnostics.md
+++ b/docs/math/13_diagnostics.md
@@ -1,0 +1,285 @@
+# Diagnostics & Likelihood
+
+A filter that runs is not a filter that works. The diagnostics in
+this chapter answer "is the assimilation statistically healthy?" —
+they *detect* misspecification (of $P$, $R$, the inflation, the
+ensemble size), they don't fix it. filterax groups them by cost:
+per-cycle health checks, calibration assessments (rolling windows,
+need a truth in twin experiments), and a-posteriori covariance
+diagnosis (long accumulations). All are pure functions under
+`filterax.utils.*` taking pre-computed arrays.
+
+## Innovation statistics
+
+Everything starts from the innovation — the part of the observation
+the forecast did not predict:
+
+$$
+d = y - \mathcal{H}(\bar{x}),
+\qquad
+S = C^{HH} + R,
+$$
+
+where $S$ is the innovation covariance: ensemble-sampled
+observation-space spread plus observation error. For a
+correctly-specified filter, $d \sim \mathcal{N}(0, S)$ — every
+diagnostic below is a different projection of that single statement.
+Componentwise, the **normalised innovation** $d_i / \sqrt{S_{ii}}$
+should be $\mathcal{N}(0,1)$; the fully whitened residual
+$S^{-1/2} d$ should be $\mathcal{N}(0, I)$.
+
+## χ² consistency
+
+Contracting $d$ against $S^{-1}$ gives the Mahalanobis statistic
+(Mehra 1970):
+
+$$
+\chi^2 = d^\top S^{-1} d,
+\qquad
+E[\chi^2] = N_y,
+\qquad
+\operatorname{Var}[\chi^2] = 2 N_y .
+$$
+
+`chi2_normalized` reports $\chi^2 / N_y$ — target $\approx 1$.
+Persistent values $> 1$ mean the filter is overconfident
+(underdispersive: inflate, chapter 12); $< 1$ means overdispersive.
+Single-window values are noisy (null standard deviation
+$\sqrt{2/N_y}$); track the running mean. The signature takes
+$S^{-1} d$ pre-computed so the diagnostic composes with whichever
+solver produced the analysis. This same ratio is the data-implied
+factor in adaptive inflation (chapter 12).
+
+## Spread-skill
+
+In twin/OSSE experiments where the truth $x^*$ is known, a
+well-calibrated ensemble has spread matching the error of its mean:
+
+$$
+\mathrm{SSR} =
+\sqrt{\frac{1}{N_x}\sum_i \sigma_i^2}
+\Bigg/
+\sqrt{\frac{1}{N_x}\sum_i \big(\bar{x}_i - x_i^*\big)^2},
+$$
+
+with $\sigma_i$ the per-variable ensemble standard deviation.
+$\mathrm{SSR} \approx 1$ is calibrated; $< 1$ underdispersive
+(increase inflation); $> 1$ overdispersive. Collapsing
+`ensemble_spread` is the earliest warning of divergence — it shows up
+before the RMSE does.
+
+## Rank histograms
+
+The rank histogram (Hamill 2001) tests calibration of the whole
+*distribution*, not just its second moment. For each variable $i$ at
+each time $t$, count how many of the $N_e$ members fall below the
+truth; the rank lands in $\{0, \dots, N_e\}$ ($N_e + 1$ bins). If
+truth and members are exchangeable, ranks are uniform. The shapes
+diagnose:
+
+- **U-shaped** — truth often outside the envelope: underdispersive.
+- **Dome-shaped** — truth always in the middle: overdispersive.
+- **Sloped** — systematic bias.
+
+`rank_histogram_chi2` turns flatness into a number:
+
+$$
+\chi^2 = \sum_k \frac{(O_k - E_k)^2}{E_k},
+\qquad
+E_k = \frac{N_{\text{total}}}{N_{\text{bins}}},
+$$
+
+distributed as $\chi^2(N_{\text{bins}} - 1)$ under the uniform null.
+
+## CRPS
+
+The Continuous Ranked Probability Score is a strictly proper scoring
+rule for the full forecast distribution against a scalar observation:
+
+$$
+\mathrm{CRPS} = E|X - y| - \tfrac{1}{2} E|X - X'|,
+$$
+
+with $X, X'$ independent draws from the forecast ensemble. filterax
+computes the second term by the sorted-ensemble identity (Hersbach
+2000),
+
+$$
+\tfrac{1}{2} E|X - X'|
+  = \frac{1}{N_e^2} \sum_{j} x_{(j)} \big( 2j - 1 - N_e \big),
+$$
+
+with $x_{(j)}$ the order statistics — $O(N_e \log N_e)$ per
+observation. Lower is better; the units are those of the observed
+variable. `crps_ensemble_batch` averages over an observation vector.
+
+## Desroziers diagnostics
+
+A long innovation record lets you estimate the error covariances *a
+posteriori* (Desroziers et al. 2005). With forecast departures
+$d_f = y - \mathcal{H}(\bar{x}^f)$ and analysis departures
+$d_a = y - \mathcal{H}(\bar{x}^a)$, consistency of the analysis
+implies the cross-statistics
+
+$$
+E\big[ d_f d_f^\top \big] \approx H P H^\top + R,
+\qquad
+E\big[ d_a d_f^\top \big] \approx R,
+\qquad
+E\big[ d_a d_a^\top \big] \approx R - H A H^\top,
+$$
+
+where $A$ is the analysis-error covariance. The middle identity is
+the workhorse: `desroziers_R_estimate` accumulates
+$\hat{R} = E[d_a d_f^\top]$ over time; disagreement with the
+prescribed $R$ means the observation-error covariance is
+misspecified. Accumulate 100+ cycles for stable estimates.
+
+## Degrees of freedom for signal
+
+How much did the observations actually constrain the analysis? With
+an explicit gain (Cardinali et al. 2004),
+
+$$
+\mathrm{DFS} = \operatorname{tr}(K H) \in [0, N_y]
+$$
+
+— close to $N_y$ when observations dominate, close to 0 when the
+prior does. Transform filters never form $K$, so `dfs_from_ensemble`
+estimates the analogous quantity from forecast/analysis
+perturbations, $\mathrm{DFS} \approx \operatorname{tr}(C^{af} /
+\sigma_f^2)$ per variable — how much the analysis anomalies remain
+driven by the forecast anomalies.
+
+## Gaussian log-likelihood
+
+The innovation likelihood is both a diagnostic and the training
+signal for differentiable DA (chapter 14):
+
+$$
+\log p(y \mid \text{forecast})
+  = -\tfrac{1}{2} \Big[
+      N_y \log(2\pi) + \log\lvert S \rvert + d^\top S^{-1} d
+    \Big].
+$$
+
+filterax builds $S$ as a `gaussx.LowRankUpdate` — base $R$ plus the
+rank-$(N_e - 1)$ ensemble term $U U^\top$ with
+$U = (HX)'^\top / \sqrt{N_e - 1}$ — so $\log|S|$ dispatches through
+the matrix-determinant lemma and $S^{-1} d$ through the Woodbury
+identity, both at $O(N_e^2 N_y + N_e^3)$ without materialising the
+dense $(N_y, N_y)$ matrix. `innovation_statistics` bundles $d$, $S$,
+the whitened residual (a true Cholesky whitening), and the
+log-likelihood in one call.
+
+## Effective ensemble size and weight entropy
+
+For weighted-ensemble variants (particle filters, hybrid schemes),
+two degeneracy monitors:
+
+$$
+N_{\mathrm{eff}} = \frac{1}{\sum_j w_j^2},
+\qquad
+H(w) = -\sum_j w_j \log w_j .
+$$
+
+Equal weights give $N_{\mathrm{eff}} = N_e$ and $H = \log N_e$;
+$N_{\mathrm{eff}} \ll N_e$ (or $H \to 0$) signals weight collapse and
+the need to resample.
+
+## Implementation in filterax
+
+```python
+import jax
+import jax.numpy as jnp
+import lineax as lx
+
+import filterax as flx
+from filterax.utils import (
+    chi2_normalized, crps_ensemble, rank_histogram, rank_histogram_chi2,
+    spread_skill_ratio,
+)
+
+k1, k2, k3, k4 = jax.random.split(jax.random.key(0), 4)
+N_e, N_x, N_y = 40, 6, 3
+
+# Twin experiment: truth and members exchangeable draws around a centre,
+# observation drawn from N(H x*, R) — a perfectly calibrated forecast.
+centre = jax.random.normal(k1, (N_x,))
+x_true = centre + jax.random.normal(k2, (N_x,))
+particles = centre + jax.random.normal(k3, (N_e, N_x))
+R = lx.DiagonalLinearOperator(0.5 * jnp.ones(N_y))
+y = x_true[:N_y] + jnp.sqrt(0.5) * jax.random.normal(k4, (N_y,))
+
+stats = flx.innovation_statistics(particles, y, lambda x: x[:N_y], R)
+d, S = stats["innovation"], stats["innovation_cov"]
+S_inv_d = jnp.linalg.solve(S.as_matrix(), d)
+print("chi2 / N_y:", float(chi2_normalized(d, S_inv_d, N_y)))
+print("log p(y | forecast):", float(stats["log_likelihood"]))
+print("spread-skill ratio:", float(spread_skill_ratio(particles, x_true)))
+
+# Rank histogram over 200 calibrated (ensemble, truth) pairs.
+def draw(key):
+    kc, kt, ke = jax.random.split(key, 3)
+    c = jax.random.normal(kc, (N_x,))
+    truth = c + jax.random.normal(kt, (N_x,))
+    ens = c + jax.random.normal(ke, (N_e, N_x))
+    return ens, truth
+
+keys = jax.random.split(jax.random.key(1), 200)
+ens_t, truth_t = jax.vmap(draw)(keys)
+counts = rank_histogram(ens_t, truth_t)
+print("rank-histogram chi2:", float(rank_histogram_chi2(counts)),
+      "~ chi2 on", counts.shape[0] - 1, "dof")
+print("CRPS:", float(crps_ensemble(particles[:, 0], x_true[0])))
+```
+
+```
+chi2 / N_y: 2.609184980392456
+log p(y | forecast): -7.225412368774414
+spread-skill ratio: 0.6982089281082153
+rank-histogram chi2: 39.08833312988281 ~ chi2 on 40 dof
+CRPS: 1.795293927192688
+```
+
+The aggregated diagnostic is clean — the rank-histogram $\chi^2$ of
+39.1 sits right at its 40-dof null expectation, confirming
+calibration. The *single-window* statistics scatter exactly as the
+nulls predict ($\chi^2/N_y$ has standard deviation $\approx 0.8$
+here): per-cycle numbers are for *tracking*, conclusions need
+windows.
+
+## Where next
+
+- [Chapter 12 — Inflation](12_inflation.md): what to do when
+  $\chi^2/N_y > 1$ — and the adaptive scheme that consumes this
+  statistic automatically.
+- [Chapter 14 — Differentiable assimilation](14_differentiable.md):
+  the log-likelihood above as a training loss.
+- [Chapter 3 — Observation model](03_observation_model.md): where $R$
+  and $\mathcal{H}$ come from; Desroziers tells you when they're
+  wrong.
+- [API: Diagnostics](../api/diagnostics.md) — the full
+  `filterax.utils.*` listing with the three-phase cost pipeline.
+
+## References
+
+- Mehra, R. K. (1970). *On the Identification of Variances and
+  Adaptive Kalman Filtering.* IEEE Trans. Automatic Control, 15(2),
+  175–184.
+- Hamill, T. M. (2001). *Interpretation of Rank Histograms for
+  Verifying Ensemble Forecasts.* Mon. Wea. Rev., 129(3), 550–560.
+- Hersbach, H. (2000). *Decomposition of the Continuous Ranked
+  Probability Score for Ensemble Prediction Systems.* Wea.
+  Forecasting, 15(5), 559–570.
+- Gneiting, T. & Raftery, A. E. (2007). *Strictly Proper Scoring
+  Rules, Prediction, and Estimation.* JASA, 102(477), 359–378.
+- Desroziers, G., Berre, L., Chapnik, B., & Poli, P. (2005).
+  *Diagnosis of observation, background and analysis-error statistics
+  in observation space.* Q. J. R. Meteorol. Soc., 131(613),
+  3385–3396.
+- Cardinali, C., Pezzulli, S., & Andersson, E. (2004).
+  *Influence-Matrix Diagnostic of a Data Assimilation System.*
+  Q. J. R. Meteorol. Soc., 130(603), 2767–2786.
+- Liu, J. S. & Chen, R. (1998). *Sequential Monte Carlo Methods for
+  Dynamic Systems.* JASA, 93(443), 1032–1044.

--- a/docs/math/14_differentiable.md
+++ b/docs/math/14_differentiable.md
@@ -1,0 +1,218 @@
+# Differentiable Assimilation
+
+Every filterax analysis step is a pure JAX computation, so the entire
+forecast–analysis cycle is differentiable by construction: `jax.grad`
+of any scalar function of the assimilation output — with respect to
+dynamics parameters, observation-operator parameters, inflation
+factors, even the initial ensemble — just works. This chapter covers
+*why* you would want that gradient, and the two strategies filterax
+ships for computing it over long windows without exhausting memory.
+
+## Why differentiate through a filter?
+
+The filter consumes a model and produces, per window, the marginal
+data likelihood $\log p(y_t \mid y_{1:t-1})$ — the Gaussian
+innovation likelihood of chapter 13. Summed over a window, this is a
+principled training signal:
+
+$$
+\mathcal{L}(\theta)
+  = -\sum_{t=1}^{T} \log p\big(y_t \mid X^f_t(\theta)\big),
+$$
+
+where $\theta$ parameterises whatever you want to learn:
+
+- **Parameter estimation** — physical constants of the forecast
+  model, observation-operator gains, error-covariance amplitudes.
+  Gradient descent on $\mathcal{L}$ replaces hand-tuning or
+  state-augmentation tricks.
+- **Learned forecast models** — train a neural surrogate (an
+  `equinox` module satisfying `AbstractDynamics`) *through* the
+  assimilation, so the model is optimised for exactly the metric the
+  DA system cares about: predicting the next observation given the
+  filtered state, rather than one-step state error in isolation.
+- **Learned codecs** — latent DA (chapter 15) backpropagates the
+  same loss into autoencoder weights.
+
+## `lax.scan` and the checkpointing trade-off
+
+The L2 wrappers (`filterax.ETKF.assimilate`, …) loop over windows in
+Python. That is differentiable for short $T$, but it unrolls into one
+giant traced graph — compile time grows with $T$ and it does not
+compose with `jax.checkpoint`. `differentiable_assimilate` is the
+drop-in replacement: observations and timestamps are stacked along a
+leading time axis and the cycle becomes a fixed-shape `jax.lax.scan`,
+giving a single fused XLA `While` whose trace is $O(1)$ in $T$.
+
+Reverse-mode AD must store the forward residuals of every step, so
+the backward tape costs $O(T \cdot N_e N_x)$ memory. Passing
+`checkpoint=True` wraps the scan body in `jax.checkpoint`
+(rematerialisation): forward intermediates are discarded and
+recomputed during the backward pass, cutting memory to
+$O(\sqrt{T} \cdot N_e N_x)$ at roughly 2–3× compute. It is a pure
+memory/compute trade — the values and gradients are unchanged.
+
+## What is refused: stochastic components
+
+Two ingredients break smooth gradients and are rejected with a
+`ValueError` at call time rather than silently producing noisy
+gradients:
+
+- **Stochastic filters** — `StochasticEnKF` (perturbed observations,
+  chapter 5) and `ETKF_Livings` (random mean-preserving rotations)
+  inject per-step PRNG draws. Under `jax.grad` the draws are treated
+  as constants, so the "gradient" is the gradient of one arbitrary
+  noise realisation. Use the deterministic square-root family
+  instead: `ETKF`, `EnSRF`, `ESTKF`, `EnSRF_Serial`, `LETKF`.
+- **`AdditiveInflator`** — the one stochastic inflator (chapter 12),
+  for the same reason. `MultiplicativeInflator` / `RTPS` / `RTPP`
+  pass through cleanly.
+
+## The ETKF `eigh` trap
+
+A subtlety worth knowing because it shaped the implementation: the
+textbook ETKF takes an eigendecomposition of the $(N_e, N_e)$
+ensemble-space matrix $\tilde{C} = (N_e-1) I + Y' R^{-1} Y'^\top$.
+When $N_y < N_e$ — the usual case — $\tilde{C}$ has $N_e - N_y$
+eigenvalues *structurally repeated* at $N_e - 1$, and the
+reverse-mode derivative of `jnp.linalg.eigh` divides by eigenvalue
+gaps: repeated eigenvalues give **NaN gradients**. filterax's ETKF
+instead extracts the rank-$N_y$ spectrum of $Y' R^{-1} Y'^\top$ via a
+thin QR plus a small $(N_y, N_y)$ `eigh`, and applies all matrix
+functions of $\tilde{C}$ in identity-plus-low-rank form — no
+degenerate eigenvectors are ever differentiated. See
+[chapter 6](06_etkf.md) for the full derivation; the practical
+consequence here is simply that `jax.grad` through the ETKF is
+NaN-free whenever $Y'$ has full column rank.
+
+## ROAD-EnKF: local gradients
+
+For very long horizons even $O(\sqrt{T})$ memory bites, and the
+full-tape gradient may not be worth its cost. ROAD-EnKF (Chen,
+Sanz-Alonso & Willett 2023) takes the **local-gradient** approach:
+
+1. At step $t$, compute the per-step loss
+   $L_t = -\log p(y_t \mid X^f_t)$ *with* gradient enabled, getting
+   the local gradient $\nabla_\theta L_t$.
+2. Sum the local gradients across steps:
+
+   $$
+   \nabla_\theta L \approx \sum_t \nabla_\theta L_t .
+   $$
+
+3. Advance the ensemble between steps through
+   `jax.lax.stop_gradient`, so no autodiff tape spans more than one
+   filter cycle.
+
+Backward-pass memory stays $O(N_e N_x)$ — **independent of $T$**.
+The price is bias: the cross-time terms
+$\partial L_t / \partial X^a_{t-1} \cdot \partial X^a_{t-1} /
+\partial \theta$ are dropped. In practice this is the accepted
+ROAD-EnKF trade-off — a stable filter forgets its initial conditions,
+so the dropped chains decay, and the memory savings dominate for long
+$T$. At $T = 1$ there are no cross-time terms and ROAD's gradient
+equals the full-tape gradient exactly (filterax pins this in
+`tests/test_road.py`).
+
+`road_enkf_loss_and_grad` returns `(loss, dynamics_grad)` where the
+gradient is a PyTree matching the dynamics module (only inexact array
+leaves carry gradients); `road_enkf_grad_step` composes it with any
+`optax` optimizer for a one-line training step.
+
+## Implementation in filterax
+
+Mirroring `tests/test_differentiable.py`'s Pattern A — learn a scalar
+dynamics parameter by descending the observation-space NLL:
+
+```python
+import jax
+import jax.numpy as jnp
+import lineax as lx
+
+import filterax as flx
+from filterax.differentiable import road_enkf_loss_and_grad
+
+
+class LinearDynamics(flx.AbstractDynamics):
+    M: jnp.ndarray
+
+    def __call__(self, state, t0, t1):
+        return self.M @ state
+
+
+# Truth evolves with M* = 0.95 I; the model starts at M = I.
+N_e, N_x, N_y, T = 20, 2, 2, 6
+key = jax.random.key(0)
+particles = jax.random.normal(key, (N_e, N_x)) + jnp.array([1.0, -0.5])
+
+state = jnp.array([1.0, -0.5])
+truth = []
+for _ in range(T):
+    state = 0.95 * state
+    truth.append(state)
+obs = jnp.stack(truth) + 0.05 * jax.random.normal(jax.random.key(1), (T, N_y))
+times = jnp.arange(1.0, T + 1.0)
+R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.05**2))
+
+
+def nll(scale):
+    dyn = LinearDynamics(M=scale * jnp.eye(N_x))
+    result = flx.differentiable_assimilate(
+        flx.filters.ETKF(), dyn, lambda x: x, particles, obs, times, R,
+        checkpoint=True,
+    )
+    return -jnp.sum(result.log_likelihoods)
+
+
+grad = jax.grad(nll)(1.0)
+print("dNLL/dscale at M = I:", float(grad))   # positive: descend toward 0.95
+print("NLL(1.00):", float(nll(1.0)))
+print("NLL(0.95):", float(nll(0.95)))
+
+# Same window through the ROAD-EnKF local-gradient path.
+loss, grads = road_enkf_loss_and_grad(
+    LinearDynamics(M=jnp.eye(N_x)), particles, obs, times, R, lambda x: x,
+)
+print("ROAD loss:", float(loss), " dM[0,0]:", float(grads.M[0, 0]))
+```
+
+```
+dNLL/dscale at M = I: 350.47052001953125
+NLL(1.00): -4.433971405029297
+NLL(0.95): -13.869117736816406
+ROAD loss: -4.433971405029297  dM[0,0]: 110.14859008789062
+```
+
+Both paths agree on the loss and on the *sign* of the gradient — the
+NLL is lower at the true $M = 0.95\,I$, and a descent step from
+$M = I$ moves toward it. The magnitudes differ because ROAD drops
+the cross-time terms; for $T = 6$ the local gradient is already a
+serviceable descent direction at a fraction of the memory.
+
+## Where next
+
+- [Chapter 6 — ETKF](06_etkf.md): the rank-$N_y$ QR + small-`eigh`
+  spectrum that makes the transform gradient-safe.
+- [Chapter 13 — Diagnostics & likelihood](13_diagnostics.md): the
+  innovation log-likelihood used as the loss, and its structured
+  $O(N_e^2 N_y + N_e^3)$ evaluation.
+- [Chapter 15 — Latent-space ensemble DA](15_latent_da.md): the same
+  gradients flowing into autoencoder weights.
+- [Chapter 5 — Stochastic EnKF](05_stochastic_enkf.md): why
+  perturbed-observation filters are excluded from training loops.
+- [API: Differentiable training](../api/differentiable.md) —
+  `differentiable_assimilate`, `road_enkf_loss_and_grad`,
+  `road_enkf_grad_step`.
+
+## References
+
+- Chen, Y., Sanz-Alonso, D., & Willett, R. (2023). *Reduced-Order
+  Autodifferentiable Ensemble Kalman Filters.* Inverse Problems,
+  39(12), 124001. (ROAD-EnKF.)
+- Griewank, A. & Walther, A. (2000). *Algorithm 799: revolve — an
+  implementation of checkpointing for the reverse or adjoint mode of
+  computational differentiation.* ACM TOMS, 26(1), 19–45. (The
+  checkpointing memory/compute trade.)
+- Bishop, C. H., Etherton, B. J., & Majumdar, S. J. (2001). *Adaptive
+  sampling with the ensemble transform Kalman filter. Part I:
+  Theoretical aspects.* Mon. Wea. Rev., 129, 420–436.

--- a/docs/math/15_latent_da.md
+++ b/docs/math/15_latent_da.md
@@ -1,0 +1,230 @@
+# Latent-Space Ensemble DA
+
+When $N_x$ is a high-resolution field — $10^6$ grid points of sea
+surface height, say — even the ensemble trick strains: every member
+must be propagated by an expensive model, the analysis manipulates
+$(N_e, N_x)$ arrays, and the sample covariance lives in a space far
+larger than the dynamics actually explore. If the system's effective
+dynamics evolve on a low-dimensional manifold, a learned autoencoder
+can expose it: assimilate in the latent space instead.
+
+## The construction
+
+Let $E: \mathbb{R}^{N_x} \to \mathbb{R}^{N_z}$ be an encoder and
+$D: \mathbb{R}^{N_z} \to \mathbb{R}^{N_x}$ a decoder, with
+$N_z \ll N_x$ and $D(E(x)) \approx x$ on the data manifold. The
+latent ensemble is the encoded ensemble, member by member:
+
+$$
+z^{(j)} = E\big(x^{(j)}\big),
+\qquad
+Z \in \mathbb{R}^{N_e \times N_z}.
+$$
+
+The entire ensemble machinery — anomalies, gain, transform,
+inflation — then runs unchanged on $Z$. Three pieces of wiring make
+the cycle close:
+
+**Lifted observation operator.** Observations live in $y$-space and
+the observation operator $\mathcal{H}$ acts on $x$-space states, so
+the latent filter observes through the composition
+
+$$
+\mathcal{H}_z = \mathcal{H} \circ D :
+\quad z \;\xrightarrow{\;D\;}\; x \;\xrightarrow{\;\mathcal{H}\;}\; y.
+$$
+
+This is filterax's `LiftedObs`: it satisfies `AbstractObsOperator`,
+so the ETKF/EnSRF/LETKF analysis only ever sees an $(N_z, N_y)$
+interface and is oblivious to the decoder inside. The observation
+error covariance $R$ operates in $y$-space and is untouched.
+Importantly, $\mathcal{H} \circ D$ is nonlinear whenever $D$ is — but
+ensemble filters never need a Jacobian; they linearise implicitly
+through the ensemble.
+
+**Latent dynamics.** Two options for the forecast:
+
+- A learned latent surrogate $M_z: z_t \mapsto z_{t+1}$ — the cheap
+  case, where the expensive physics is replaced by a small network
+  trained alongside the codec (`LatentDynamics` wraps any object with
+  `.step(z, dt)`).
+- The original $x$-space model lifted through the codec round-trip,
+
+  $$
+  z_{t+1} = E\big( M\big( D(z_t) \big) \big)
+  $$
+
+  (`EncodedDynamics`) — no forecast speedup, but the *analysis* still
+  runs in $\mathbb{R}^{N_z}$.
+
+## When latent DA pays
+
+- **High-dimensional fields with low intrinsic dimension.** The
+  analysis cost terms in $N_x$ become terms in $N_z$; an
+  $N_e = 50$ ensemble that is hopelessly rank-deficient in
+  $\mathbb{R}^{10^6}$ can be a *generous* sample of
+  $\mathbb{R}^{64}$.
+- **Learned autoencoders already in the pipeline.** If a codec was
+  trained for compression or emulation, assimilating in its latent
+  space is nearly free — and the codec can be *fine-tuned through
+  the filter*, since the whole construction is differentiable
+  (chapter 14): gradients of the assimilation NLL flow into encoder
+  and decoder weights.
+- **Non-Gaussian state distributions.** A good encoder Gaussianises:
+  the Kalman update's Gaussian assumption can hold better in $z$ than
+  in $x$.
+
+The caveat: analysis increments are confined to the decoder's range.
+Whatever the codec cannot represent, the filter cannot correct. And
+localization is problematic — latent dimensions of a typical
+autoencoder are *global* modes with no intrinsic notion of physical
+distance, which is why `LatentLETKF` in v0.1 deliberately applies
+**no** localization in latent space (it is API parity for pipeline
+wiring; its body matches `LatentETKF`).
+
+## The two views: `LatentAssimilationResult`
+
+The L2 wrappers surface both representations. The `_z` fields
+(`particles_z`, `forecast_history_z`, `analysis_history_z`) are the
+*primary* representation — the arrays the filter actually updated.
+The $x$-space fields (`particles`, `forecast_history`,
+`analysis_history`) are decoded views, provided so downstream
+smoothers, diagnostics, and plots work unchanged. The
+log-likelihoods are computed in observation space and are common to
+both views. As always, axis 0 of each ensemble array is the member
+axis and histories stack along a leading $T$ axis.
+
+A useful regression anchor: with the identity codec
+($E = D = \mathrm{id}$, `identity_latent_map`), `LatentETKF` must
+reproduce plain `ETKF` bit-for-bit — the wrapper adds wiring, not
+math.
+
+## Implementation in filterax
+
+Mirroring `tests/test_latent.py`: first the identity-codec parity
+pin, then a dimension-reducing linear codec with a raw latent forward
+model (auto-wrapped from its `.step(z, dt)` method):
+
+```python
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+
+import filterax as flx
+
+
+class LinearObs(flx.AbstractObsOperator):
+    H: jnp.ndarray
+
+    def __call__(self, state):
+        return self.H @ state
+
+
+class IdentityDynamics(flx.AbstractDynamics):
+    def __call__(self, state, t0, t1):
+        return state
+
+
+# Identity codec: LatentETKF must reproduce plain ETKF.
+key = jax.random.key(0)
+N_e, N_x, N_y = 30, 4, 2
+particles = jax.random.normal(key, (N_e, N_x))
+obs_op = LinearObs(H=jnp.eye(N_x)[:N_y])
+R = lx.DiagonalLinearOperator(jnp.full((N_y,), 0.4))
+obs_seq = [(jnp.array([0.3, -0.1]), 1.0), (jnp.array([0.2, 0.0]), 2.0)]
+
+plain = flx.ETKF(dynamics=IdentityDynamics(), obs_op=obs_op).assimilate(
+    particles, obs_seq, R
+)
+lm = flx.identity_latent_map(dim=N_x)
+latent = flx.LatentETKF(
+    latent_map=lm, dynamics=IdentityDynamics(), obs_op=obs_op
+).assimilate(particles, obs_seq, R)
+
+print("x-view matches ETKF:",
+      bool(jnp.allclose(latent.particles, plain.particles, atol=1e-6)))
+print("z-view == x-view under identity codec:",
+      bool(jnp.allclose(latent.particles_z, latent.particles)))
+
+
+# Dimension-reducing codec: assimilate in R^2 while observing R^4 fields.
+class Codec(eqx.Module):
+    W_enc: jnp.ndarray
+    W_dec: jnp.ndarray
+
+    def encode(self, x):
+        return self.W_enc @ x
+
+    def decode(self, z):
+        return self.W_dec @ z
+
+
+class LatentForward(eqx.Module):
+    A: jnp.ndarray
+
+    def step(self, z, dt):
+        return self.A @ z
+
+
+N_z = 2
+k1, k2 = jax.random.split(jax.random.key(1))
+codec = Codec(W_enc=jax.random.normal(k1, (N_z, N_x)),
+              W_dec=jax.random.normal(k2, (N_x, N_z)))
+fwd = LatentForward(A=0.9 * jnp.eye(N_z))   # raw .step(z, dt) — auto-wrapped
+
+res = flx.LatentETKF(latent_map=codec, dynamics=fwd, obs_op=obs_op).assimilate(
+    particles, obs_seq, R
+)
+print("x-space analysis:", res.analysis_history.shape)
+print("z-space analysis:", res.analysis_history_z.shape)
+print("log-likelihoods:", res.log_likelihoods.shape)
+```
+
+```
+x-view matches ETKF: True
+z-view == x-view under identity codec: True
+x-space analysis: (2, 30, 4)
+z-space analysis: (2, 30, 2)
+log-likelihoods: (2,)
+```
+
+The second filter forecast and analysed a 2-dimensional latent
+ensemble while observing (and reporting) 4-dimensional states; the
+analysis arrays come back in both coordinate systems. With
+`in_x_space=False`, `assimilate` accepts a pre-encoded $(N_e, N_z)$
+ensemble and skips the initial encode.
+
+A real workflow replaces `Codec` with a trained autoencoder (any
+`eqx.Module` exposing `.encode`/`.decode` — structurally compatible
+with `pipekit_cycle.LatentMap`) and `LatentForward` with a learned
+latent surrogate; nothing else changes.
+
+## Where next
+
+- [Chapter 6 — ETKF](06_etkf.md): the analysis step running
+  underneath, unchanged in $z$-space.
+- [Chapter 14 — Differentiable assimilation](14_differentiable.md):
+  training codec and latent dynamics through the filter.
+- [Chapter 8 — LETKF](08_letkf.md): why R-localization needs physical
+  coordinates — and hence why `LatentLETKF` skips it.
+- [Chapter 16 — The assimilation cycle](16_assimilation_cycle.md):
+  wiring latent filters into pipekit-cycle orchestration.
+- [API: Advanced filters](../api/filters_advanced.md) — `LatentETKF`,
+  `LatentLETKF`, `LiftedObs`, `LatentDynamics`, `EncodedDynamics`,
+  `identity_latent_map`.
+
+## References
+
+- Peyron, M., Fillion, A., Gürol, S., Marchais, V., Gratton, S.,
+  Boudier, P., & Goret, G. (2021). *Latent space data assimilation by
+  using deep learning.* Q. J. R. Meteorol. Soc., 147(740),
+  3759–3777.
+- Amendola, M., Arcucci, R., Mottet, L., Casas, C. Q., Fan, S., Pain,
+  C., Linden, P., & Guo, Y.-K. (2021). *Data assimilation in the
+  latent space of a convolutional autoencoder.* ICCS 2021, LNCS
+  12746.
+- Chen, Y., Sanz-Alonso, D., & Willett, R. (2023). *Reduced-Order
+  Autodifferentiable Ensemble Kalman Filters.* Inverse Problems,
+  39(12), 124001. (Jointly learns the latent surrogate and decoder
+  through the filter.)

--- a/docs/math/16_assimilation_cycle.md
+++ b/docs/math/16_assimilation_cycle.md
@@ -1,0 +1,221 @@
+# The Assimilation Cycle
+
+Chapters 4–8 derived analysis steps in isolation: one forecast
+ensemble in, one posterior ensemble out. Real assimilation is a
+*cycle* — forecast, analyse, inflate, repeat — and this chapter
+covers how filterax layers that cycle and how it plugs into external
+orchestration through pipekit-cycle.
+
+## Two layers
+
+filterax separates the mathematics from the loop:
+
+**L1 — the analysis step.** A stateless `AbstractSequentialFilter`
+(`filters.ETKF()`, `filters.EnSRF()`, `filters.LETKF(radius=...)`, …)
+whose single method
+
+$$
+\texttt{analysis}(X^f,\, y,\, \mathcal{H},\, R)
+\;\longmapsto\; \texttt{AnalysisResult}
+$$
+
+maps a forecast ensemble to a posterior ensemble. `AnalysisResult`
+carries the posterior `particles` $(N_e, N_x)$, the scalar
+`log_likelihood` $\log p(y \mid \text{forecast})$ (populated by every
+deterministic filter), and an optional `diagnostics` dict. L1 owns
+no time, no dynamics, no state.
+
+**L2 — the forecast–analyse–inflate loop.** The high-level models
+(`filterax.ETKF`, `EnSRF`, `LETKF`, `StochasticEnKF`, and the latent
+wrappers of chapter 15) compose three configuration objects —
+`dynamics`, `obs_op`, optional `inflator` — and run, for each
+observation window $(y_t, t)$:
+
+$$
+X^f_t = \mathcal{M}_{t-1 \to t}\big(X^a_{t-1}\big)
+\;\longrightarrow\;
+X^a_t = \text{analysis}\big(X^f_t, y_t\big)
+\;\longrightarrow\;
+X^a_t \leftarrow \text{inflate}\big(X^a_t, X^f_t\big),
+$$
+
+with the dynamics `vmap`-ed over members and the inflator receiving
+both ensembles so RTPS/RTPP can relax toward the prior (chapter 12).
+The result is an `AssimilationResult`: terminal `particles`, plus
+`forecast_history` and `analysis_history` stacked $(T, N_e, N_x)$
+along a leading time axis, plus length-$T$ `log_likelihoods`
+(NaN-padded where a filter produces none, so the time axes stay
+aligned).
+
+The L2 loop is a deliberately thin Python `for` — easy to read, easy
+to replace. When you need a fused `lax.scan` (long $T$, gradient
+checkpointing), `differentiable_assimilate` is the drop-in
+(chapter 14); when you need external orchestration, the adapters
+below are.
+
+## Cycling through pipekit-cycle
+
+[pipekit-cycle](https://github.com/jejjohnson/pipekit) orchestrates
+DA cycles for *any* algorithm library through three
+runtime-checkable Protocols:
+
+| Protocol | Contract |
+|---|---|
+| `AnalysisStep` | `__call__(forecast, obs, *, obs_op, obs_err_cov)` |
+| `ForwardModel` | `step(state, dt)` + `dt` / `state_signature` attributes |
+| `ObservationOperator` | `__call__(state)` + `linearize(state)` |
+
+Conformance is **structural** — filterax never imports pipekit, and
+pipekit never imports filterax. The adapters in `filterax.pipekit`
+lift filterax components into the protocol shapes, and pipekit's
+`isinstance` checks against its runtime-checkable Protocols pass:
+
+- **`FilterAnalysisStep`** wraps any `AbstractSequentialFilter` as an
+  `AnalysisStep`. It absorbs the main impedance mismatch: pipekit's
+  `EnsembleDACycle` represents the ensemble as a Python **list of
+  member states**, while filterax stacks members along axis 0 of a
+  single array. The adapter stacks a list on the way in and returns
+  the same container kind it received — list in, list out; array in,
+  array out. It also coerces a dense `(N_y, N_y)` `obs_err_cov`
+  array into a tagged lineax operator (an explicit error is raised
+  when it is missing). Extra per-cycle analysis kwargs (LETKF's
+  `state_coords` / `obs_coords`) ride along via `analysis_kwargs`.
+- **`DynamicsForwardModel`** wraps an `AbstractDynamics` as a
+  `ForwardModel`. pipekit does not thread absolute time into `step`,
+  so the dynamics are treated as autonomous and integrated over
+  $[0, dt]$.
+- **`LinearizableObsOperator`** wraps an `AbstractObsOperator` (or
+  plain callable) as an `ObservationOperator`, deriving `linearize`
+  from `jax.jacfwd` — any JAX-traceable $\mathcal{H}$ gets an exact
+  $(N_y, N_x)$ Jacobian for free.
+
+**Randomness note.** pipekit never passes a PRNG key to the analysis
+step, so a stochastic filter wrapped in `FilterAnalysisStep` draws
+from the key it was constructed with — the *same* perturbations every
+cycle. Prefer deterministic filters (ETKF, EnSRF) when cycling
+through pipekit, or reconstruct the filter per cycle.
+
+## Implementation in filterax
+
+The adapter layer is pure filterax and runs without pipekit
+installed:
+
+```python
+import jax.numpy as jnp
+
+from filterax.filters import ETKF
+from filterax.pipekit import (
+    DynamicsForwardModel,
+    FilterAnalysisStep,
+    LinearizableObsOperator,
+)
+
+# Analysis step: list-of-members in, list-of-members out (pipekit's
+# EnsembleDACycle container), or stacked array in / array out.
+step = FilterAnalysisStep(ETKF())
+members = [jnp.array([0.0, 0.0]), jnp.array([1.0, 1.0]), jnp.array([2.0, 0.5])]
+analysed = step(
+    members,
+    jnp.array([0.5, 0.5]),
+    obs_op=lambda x: x,
+    obs_err_cov=0.1 * jnp.eye(2),       # dense array — coerced to lineax
+)
+print("container preserved:", type(analysed).__name__, len(analysed))
+
+# Forward model: autonomous step(state, dt) + dt attribute.
+fwd = DynamicsForwardModel(lambda x, t0, t1: x + 0.1 * (t1 - t0), dt=0.5)
+print("step:", fwd.step(jnp.array([1.0, 2.0]), fwd.dt))
+
+# Observation operator: __call__ + linearize via jax.jacfwd.
+H = LinearizableObsOperator(lambda x: x[:1] ** 2)
+print("H(x):", H(jnp.array([3.0, 4.0])), " dH/dx:", H.linearize(jnp.array([3.0, 4.0])))
+```
+
+```
+container preserved: list 3
+step: [1.05 2.05]
+H(x): [9.]  dH/dx: [[6. 0.]]
+```
+
+### Wiring an `EnsembleDACycle`
+
+The full cycle wiring requires `pipekit_cycle` to be installed, so
+the block below is **illustrative only** (not executed here; the
+filterax-side adapter behaviour it relies on is exactly what ran
+above, and `tests/test_pipekit_integration.py` runs the real
+`isinstance` conformance checks whenever `pipekit_cycle` is
+importable):
+
+```python
+# Illustrative — requires `pipekit_cycle` to be installed.
+import jax.numpy as jnp
+from pipekit_cycle import DAState, EnsembleDACycle
+
+from filterax.filters import ETKF
+from filterax.pipekit import (
+    DynamicsForwardModel,
+    FilterAnalysisStep,
+    LinearizableObsOperator,
+)
+
+cycle = EnsembleDACycle(
+    forward=DynamicsForwardModel(my_dynamics, dt=0.5),
+    obs_op=LinearizableObsOperator(lambda x: x[::4]),
+    analysis=FilterAnalysisStep(ETKF()),
+)
+state = DAState(
+    ensemble=[x0 + perturbation(j) for j in range(N_e)],   # list of members
+    obs_err_cov=0.1 * jnp.eye(N_y),
+)
+for y_t in observation_stream:
+    state = cycle.run(state, obs=y_t)
+```
+
+pipekit owns the loop, the scheduling, and the state container;
+filterax owns the ensemble mathematics inside `FilterAnalysisStep`.
+Swapping `ETKF()` for `EnSRF()`, `LETKF(radius=...)` (with
+`analysis_kwargs={"state_coords": ..., "obs_coords": ...}`), or an
+analysis step from an entirely different library changes nothing
+else in the pipeline — that is the point of the protocols.
+
+## Choosing your loop
+
+| Need | Use |
+|---|---|
+| Quick experiment, short $T$ | L2 `model.assimilate(...)` Python loop |
+| Training through the filter, long $T$ | `differentiable_assimilate` (scan + checkpoint) |
+| $T$-independent gradient memory | `road_enkf_loss_and_grad` |
+| External orchestration / mixed libraries | pipekit-cycle + `filterax.pipekit` adapters |
+| Custom cycling logic | roll your own around L1 `filter.analysis(...)` |
+
+All five paths call the same L1 analysis code, so results are
+consistent across them — the differentiable loop is pinned
+step-for-step to the L2 loop in `tests/test_differentiable.py`, and
+the adapter to the direct analysis call in
+`tests/test_pipekit_integration.py`.
+
+## Where next
+
+- [Chapter 1 — Problem setting](01_problem_setting.md): the
+  filtering recursion this cycle implements.
+- [Chapter 12 — Inflation](12_inflation.md): the inflate leg of the
+  L2 loop.
+- [Chapter 14 — Differentiable assimilation](14_differentiable.md):
+  the scan-based replacement for the Python loop.
+- [Chapter 15 — Latent-space ensemble DA](15_latent_da.md): the L2
+  latent wrappers that reuse this exact loop in $z$-space.
+- [API: pipekit integration](../api/pipekit.md) — adapter reference
+  and a full `EnsembleDACycle` example.
+- [API: Protocols & Types](../api/protocols.md) — `AnalysisResult`,
+  `AssimilationResult`, and the abstract component classes.
+
+## References
+
+- Carrassi, A., Bocquet, M., Bertino, L., & Evensen, G. (2018).
+  *Data assimilation in the geosciences: An overview of methods,
+  issues, and perspectives.* WIREs Climate Change, 9(5), e535.
+- Asch, M., Bocquet, M., & Nodet, M. (2016). *Data Assimilation:
+  Methods, Algorithms, and Applications.* SIAM. (Ch. 1 frames the
+  forecast–analysis cycle.)
+- Evensen, G. (2009). *Data Assimilation: The Ensemble Kalman
+  Filter.* 2nd ed., Springer.

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -1,0 +1,113 @@
+# Notation
+
+Conventions used throughout the Mathematical Reference. The single
+most important one: **the ensemble matrix stacks members as rows**,
+$X \in \mathbb{R}^{N_e \times N_x}$, so axis 0 of every ensemble
+array is the ensemble axis — matching the `(N_e, N_x)` shape of every
+filterax `particles` argument.
+
+## Dimensions
+
+| Symbol | Description |
+|---|---|
+| $N_e$ | Ensemble size (number of members) |
+| $N_x$ | State dimension |
+| $N_y$ | Observation dimension (per assimilation window) |
+| $N_z$ | Latent dimension (chapter 15) |
+| $T$ | Number of assimilation windows / time steps |
+| $J$, $N_p$, $N_d$ | Ensemble size, parameter dim, data dim for EKP processes (chapter 9) |
+
+## Ensemble quantities
+
+| Symbol | Description |
+|---|---|
+| $X \in \mathbb{R}^{N_e \times N_x}$ | Ensemble matrix; members as rows, axis 0 = ensemble |
+| $x^{(j)}$ | The $j$-th ensemble member (a row of $X$) |
+| $\bar{x} = \frac{1}{N_e} \sum_j x^{(j)}$ | Ensemble mean |
+| $X' = X - \mathbf{1}\bar{x}^\top$ | Anomaly (perturbation) matrix |
+| $P = \frac{1}{N_e - 1} X'^\top X'$ | Sample (forecast-error) covariance, Bessel-corrected |
+| $Y = \mathcal{H}(X)$ | Ensemble mapped to observation space, $(N_e, N_y)$ |
+| $Y'$ | Observation-space anomaly matrix |
+| $C^{xH}$ | State–observation cross-covariance $\frac{1}{N_e-1} X'^\top Y'$ |
+| $C^{HH}$ | Observation-space covariance $\frac{1}{N_e-1} Y'^\top Y'$ |
+| $\cdot^f$, $\cdot^a$ | Forecast (prior) / analysis (posterior) superscripts |
+| $\sigma_i$ | Per-variable ensemble standard deviation (spread) |
+| $w_j$ | Importance weight of member $j$ |
+
+## Observation model
+
+| Symbol | Description |
+|---|---|
+| $y \in \mathbb{R}^{N_y}$ | Observation vector |
+| $\mathcal{H}$ | Observation operator (possibly nonlinear); $H$ its linear(ised) matrix form |
+| $R$ | Observation error covariance |
+| $d = y - \mathcal{H}(\bar{x})$ | Innovation (also $v$ in some L1 docstrings) |
+| $S = C^{HH} + R$ | Innovation covariance |
+| $K = C^{xH} S^{-1}$ | (Ensemble) Kalman gain |
+| $U = (HX)'^\top / \sqrt{N_e - 1}$ | Low-rank factor of the ensemble term in $S$ |
+
+## Transforms and dynamics
+
+| Symbol | Description |
+|---|---|
+| $\mathcal{M}$, $M$ | Forecast model (dynamics); $M_z$ a latent surrogate |
+| $\tilde{C} = (N_e - 1) I + Y' R^{-1} Y'^\top$ | ETKF ensemble-space transform precision |
+| $W$ (also $W_a$) | Ensemble transform / perturbation-weight matrix |
+| $\bar{w}$ | Mean-update weight vector in ensemble space |
+| $\Theta$ | Mean-preserving random rotation (ETKF-Livings) |
+| $E$, $D$ | Encoder / decoder of a latent map; $z = E(x)$, $x \approx D(z)$ |
+| $\theta$ | Trainable parameters (chapter 14) |
+| $\mathcal{L}$, $L_t$ | Training loss; per-step local loss (ROAD-EnKF) |
+
+## Localization and inflation
+
+| Symbol | Description |
+|---|---|
+| $\rho$ | Localization taper (function or matrix); entries in $[0, 1]$ |
+| $r$ | Localization half-width; compactly supported tapers vanish at $2r$ |
+| $\circ$ | Schur (Hadamard, element-wise) matrix product |
+| $\rho^{xy}$, $\rho^{yy}$ | State–obs and obs–obs taper matrices |
+| $d_{ij}$ | Physical distance between variables $i$ and $j$ |
+| $\lambda$ | Multiplicative inflation factor ($X' \leftarrow \lambda X'$) |
+| $\alpha$ | Relaxation coefficient (RTPS / RTPP), in $[0, 1]$ |
+| $Q_{\text{add}}$ | Additive-inflation (model-error) covariance |
+| $\lambda^*$, $\mu$ | Ledoit-Wolf shrinkage intensity; average sample eigenvalue $\operatorname{tr}(P)/N_x$ |
+
+## Diagnostics
+
+| Symbol | Description |
+|---|---|
+| $\chi^2 = d^\top S^{-1} d$ | Innovation consistency statistic; $E[\chi^2] = N_y$ |
+| $d_f$, $d_a$ | Forecast / analysis departures (Desroziers) |
+| $\mathrm{SSR}$ | Spread-skill ratio (RMS spread / RMSE of the mean) |
+| $\mathrm{DFS} = \operatorname{tr}(KH)$ | Degrees of freedom for signal |
+| $\mathrm{CRPS}$ | Continuous Ranked Probability Score |
+| $N_{\mathrm{eff}} = 1 / \sum_j w_j^2$ | Effective ensemble size |
+| $A$ | Analysis-error covariance (in Desroziers identities) |
+
+## General
+
+| Symbol | Description |
+|---|---|
+| $\mathbf{1}$ | Vector of ones, $(N_e,)$ unless stated otherwise |
+| $I$ | Identity matrix |
+| $\mathcal{N}(\mu, \Sigma)$ | Gaussian distribution |
+| $\varepsilon$ | Random perturbation / noise draw |
+| $\lVert \cdot \rVert_F$ | Frobenius norm |
+| $\operatorname{tr}(\cdot)$ | Matrix trace |
+| $E[\cdot]$ | Expectation |
+| $\mathbb{1}\{\cdot\}$ | Indicator function |
+| $x^*$ | True state (twin / OSSE experiments) |
+
+## filterax shape conventions
+
+| Array | Shape |
+|---|---|
+| Ensemble (`particles`) | `(N_e, N_x)` |
+| Observation-space ensemble | `(N_e, N_y)` |
+| Observation vector | `(N_y,)` |
+| Kalman gain | `(N_x, N_y)` |
+| Taper matrices `rho_xy` / `rho_yy` | `(N_x, N_y)` / `(N_y, N_y)` |
+| Stacked histories (`*_history`) | `(T, N_e, N_x)` |
+| Stacked observations (differentiable loop) | `(T, N_y)` |
+| Latent ensemble | `(N_e, N_z)` |

--- a/docs/math/references.md
+++ b/docs/math/references.md
@@ -1,0 +1,200 @@
+# References
+
+Master reference list for the Mathematical Reference, grouped by
+chapter. Per-chapter lists repeat the most load-bearing entries.
+
+## Foundational DA texts
+
+1. Evensen, G. (2009). *Data Assimilation: The Ensemble Kalman
+   Filter.* 2nd ed., Springer.
+2. Carrassi, A., Bocquet, M., Bertino, L., & Evensen, G. (2018).
+   *Data assimilation in the geosciences: An overview of methods,
+   issues, and perspectives.* WIREs Climate Change, 9(5), e535.
+3. Asch, M., Bocquet, M., & Nodet, M. (2016). *Data Assimilation:
+   Methods, Algorithms, and Applications.* SIAM.
+4. Evensen, G. (2003). *The Ensemble Kalman Filter: theoretical
+   formulation and practical implementation.* Ocean Dynamics, 53,
+   343–367.
+
+## EnKF — stochastic formulation (chapters 4–5)
+
+5. Evensen, G. (1994). *Sequential data assimilation with a nonlinear
+   quasi-geostrophic model using Monte Carlo methods to forecast
+   error statistics.* J. Geophys. Res., 99(C5), 10143–10162.
+6. Burgers, G., van Leeuwen, P. J., & Evensen, G. (1998). *Analysis
+   scheme in the ensemble Kalman filter.* Mon. Wea. Rev., 126,
+   1719–1724.
+
+## ETKF and square-root variants (chapters 6–7)
+
+7. Bishop, C. H., Etherton, B. J., & Majumdar, S. J. (2001).
+   *Adaptive sampling with the ensemble transform Kalman filter.
+   Part I: Theoretical aspects.* Mon. Wea. Rev., 129, 420–436.
+8. Wang, X., Bishop, C. H., & Julier, S. J. (2004). *Which is better,
+   an ensemble of positive–negative pairs or a centered spherical
+   simplex ensemble?* Mon. Wea. Rev., 132, 1590–1605. (Square-root
+   choices; the symmetric square root.)
+9. Livings, D. M., Dance, S. L., & Nichols, N. K. (2008). *Unbiased
+   ensemble square root filters.* Physica D, 237(8), 1021–1028.
+10. Sakov, P. & Oke, P. R. (2008). *Implications of the form of the
+    ensemble transformation in the ensemble square root filters.*
+    Mon. Wea. Rev., 136, 1042–1053.
+11. Whitaker, J. S. & Hamill, T. M. (2002). *Ensemble data
+    assimilation without perturbed observations.* Mon. Wea. Rev.,
+    130, 1913–1924. (EnSRF / serial assimilation.)
+12. Nerger, L., Janjić, T., Schröter, J., & Hiller, W. (2012). *A
+    unification of ensemble square root Kalman filters.* Mon. Wea.
+    Rev., 140, 2335–2345. (ESTKF.)
+13. Tippett, M. K., Anderson, J. L., Bishop, C. H., Hamill, T. M., &
+    Whitaker, J. S. (2003). *Ensemble square root filters.* Mon.
+    Wea. Rev., 131, 1485–1490.
+
+## LETKF (chapter 8)
+
+14. Hunt, B. R., Kostelich, E. J., & Szunyogh, I. (2007). *Efficient
+    data assimilation for spatiotemporal chaos: A local ensemble
+    transform Kalman filter.* Physica D, 230, 112–126.
+15. Ott, E., Hunt, B. R., Szunyogh, I., Zimin, A. V., Kostelich,
+    E. J., Corazza, M., Kalnay, E., Patil, D. J., & Yorke, J. A.
+    (2004). *A local ensemble Kalman filter for atmospheric data
+    assimilation.* Tellus A, 56(5), 415–428.
+
+## Ensemble Kalman processes — EKI / EKS / UKI (chapter 9)
+
+16. Iglesias, M. A., Law, K. J. H., & Stuart, A. M. (2013).
+    *Ensemble Kalman methods for inverse problems.* Inverse
+    Problems, 29(4), 045001.
+17. Garbuno-Inigo, A., Hoffmann, F., Li, W., & Stuart, A. M. (2020).
+    *Interacting Langevin diffusions: Gradient structure and ensemble
+    Kalman sampler.* SIAM J. Appl. Dyn. Syst., 19(1), 412–441.
+18. Huang, D. Z., Schneider, T., & Stuart, A. M. (2022). *Iterated
+    Kalman methodology for inverse problems.* J. Comput. Phys., 463,
+    111262. (UKI.)
+19. Kovachki, N. B. & Stuart, A. M. (2019). *Ensemble Kalman
+    inversion: a derivative-free technique for machine learning
+    tasks.* Inverse Problems, 35(9), 095005.
+20. Iglesias, M. A. (2016). *A regularizing iterative ensemble Kalman
+    method for PDE-constrained inverse problems.* Inverse Problems,
+    32(2), 025002. (Data-misfit step-size control.)
+
+## Smoothers (chapter 10)
+
+21. Evensen, G. & van Leeuwen, P. J. (2000). *An ensemble Kalman
+    smoother for nonlinear dynamics.* Mon. Wea. Rev., 128,
+    1852–1867.
+22. Cosme, E., Verron, J., Brasseur, P., Blum, J., & Auroux, D.
+    (2012). *Smoothing problems in a Bayesian framework and their
+    linear Gaussian solutions.* Mon. Wea. Rev., 140, 683–695.
+23. Chen, Y. & Oliver, D. S. (2013). *Levenberg–Marquardt forms of
+    the iterative ensemble smoother for efficient history matching
+    and uncertainty quantification.* Comput. Geosci., 17, 689–703.
+    (IES.)
+24. Bocquet, M. & Sakov, P. (2014). *An iterative ensemble Kalman
+    smoother.* Q. J. R. Meteorol. Soc., 140(682), 1521–1535.
+25. Whitaker, J. S. & Compo, G. P. (2002). *An ensemble Kalman
+    smoother for reanalysis.* Proc. Symp. on Observations, Data
+    Assimilation and Probabilistic Prediction, AMS.
+26. Evensen, G., Raanes, P. N., Stordal, A. S., & Hove, J. (2019).
+    *Efficient implementation of an iterative ensemble smoother for
+    data assimilation and reservoir characterization.* Front. Appl.
+    Math. Stat., 5, 47.
+
+## Localization (chapter 11)
+
+27. Gaspari, G. & Cohn, S. E. (1999). *Construction of correlation
+    functions in two and three dimensions.* Q. J. R. Meteorol. Soc.,
+    125, 723–757.
+28. Houtekamer, P. L. & Mitchell, H. L. (2001). *A sequential
+    ensemble Kalman filter for atmospheric data assimilation.* Mon.
+    Wea. Rev., 129, 123–137.
+29. Anderson, J. L. (2007). *Exploring the need for localization in
+    ensemble data assimilation using a hierarchical ensemble
+    filter.* Physica D, 230, 99–111.
+30. Thiebaux, H. J. & Pedder, M. A. (1987). *Spatial Objective
+    Analysis.* Academic Press. (SOAR correlation model.)
+
+## Inflation (chapter 12)
+
+31. Anderson, J. L. & Anderson, S. L. (1999). *A Monte Carlo
+    implementation of the nonlinear filtering problem to produce
+    ensemble assimilations and forecasts.* Mon. Wea. Rev., 127,
+    2741–2758.
+32. Zhang, F., Snyder, C., & Sun, J. (2004). *Impacts of initial
+    estimate and observation availability on convective-scale data
+    assimilation.* Mon. Wea. Rev., 132, 1238–1253. (RTPP.)
+33. Whitaker, J. S. & Hamill, T. M. (2012). *Evaluating methods to
+    account for system errors in ensemble data assimilation.* Mon.
+    Wea. Rev., 140, 3078–3089. (RTPS.)
+34. Anderson, J. L. (2009). *Spatially and temporally varying
+    adaptive covariance inflation for ensemble filters.* Tellus A,
+    61, 72–83.
+35. Hamill, T. M. & Whitaker, J. S. (2005). *Accounting for the
+    error due to unresolved scales in ensemble data assimilation: A
+    comparison of different approaches.* Mon. Wea. Rev., 133,
+    3132–3147. (Additive inflation.)
+36. Ledoit, O. & Wolf, M. (2004). *A well-conditioned estimator for
+    large-dimensional covariance matrices.* J. Multivariate Anal.,
+    88, 365–411.
+
+## Diagnostics (chapter 13)
+
+37. Desroziers, G., Berre, L., Chapnik, B., & Poli, P. (2005).
+    *Diagnosis of observation, background and analysis-error
+    statistics in observation space.* Q. J. R. Meteorol. Soc.,
+    131(613), 3385–3396.
+38. Hersbach, H. (2000). *Decomposition of the Continuous Ranked
+    Probability Score for Ensemble Prediction Systems.* Wea.
+    Forecasting, 15(5), 559–570.
+39. Hamill, T. M. (2001). *Interpretation of Rank Histograms for
+    Verifying Ensemble Forecasts.* Mon. Wea. Rev., 129(3), 550–560.
+40. Mehra, R. K. (1970). *On the Identification of Variances and
+    Adaptive Kalman Filtering.* IEEE Trans. Automatic Control,
+    15(2), 175–184.
+41. Cardinali, C., Pezzulli, S., & Andersson, E. (2004).
+    *Influence-Matrix Diagnostic of a Data Assimilation System.*
+    Q. J. R. Meteorol. Soc., 130(603), 2767–2786.
+42. Gneiting, T. & Raftery, A. E. (2007). *Strictly Proper Scoring
+    Rules, Prediction, and Estimation.* JASA, 102(477), 359–378.
+43. Fortin, V., Abaza, M., Anctil, F., & Turcotte, R. (2014). *Why
+    Should Ensemble Spread Match the RMSE of the Ensemble Mean?*
+    J. Hydrometeorol., 15(4), 1708–1713.
+44. Whitaker, J. S. & Loughe, A. F. (1998). *The Relationship
+    between Ensemble Spread and Ensemble Mean Skill.* Mon. Wea.
+    Rev., 126(12), 3292–3302.
+45. Liu, J. S. & Chen, R. (1998). *Sequential Monte Carlo Methods
+    for Dynamic Systems.* JASA, 93(443), 1032–1044.
+
+## Differentiable & latent DA (chapters 14–15)
+
+46. Chen, Y., Sanz-Alonso, D., & Willett, R. (2023). *Reduced-Order
+    Autodifferentiable Ensemble Kalman Filters.* Inverse Problems,
+    39(12), 124001. (ROAD-EnKF.)
+47. Griewank, A. & Walther, A. (2000). *Algorithm 799: revolve — an
+    implementation of checkpointing for the reverse or adjoint mode
+    of computational differentiation.* ACM TOMS, 26(1), 19–45.
+48. Peyron, M., Fillion, A., Gürol, S., Marchais, V., Gratton, S.,
+    Boudier, P., & Goret, G. (2021). *Latent space data assimilation
+    by using deep learning.* Q. J. R. Meteorol. Soc., 147(740),
+    3759–3777.
+49. Amendola, M., Arcucci, R., Mottet, L., Casas, C. Q., Fan, S.,
+    Pain, C., Linden, P., & Guo, Y.-K. (2021). *Data assimilation in
+    the latent space of a convolutional autoencoder.* ICCS 2021,
+    LNCS 12746.
+
+## Ecosystem libraries
+
+- [`gaussx`](https://github.com/jejjohnson/gaussx) — structured
+  linear operators; the Woodbury / matrix-determinant-lemma dispatch
+  behind the gain and likelihood, the Gaspari-Cohn taper, and the
+  classic inflation trio.
+- [`lineax`](https://github.com/patrick-kidger/lineax) — linear
+  operators and solvers (`AbstractLinearOperator` for $R$, $Q$).
+- [`equinox`](https://github.com/patrick-kidger/equinox) — module
+  system; every filterax component is an `eqx.Module` PyTree.
+- [`optax`](https://github.com/google-deepmind/optax) — optimizers
+  for the differentiable-training surface.
+- [`pipekit`](https://github.com/jejjohnson/pipekit) +
+  `pipekit-cycle` — operator composition and the DA-cycle protocols
+  of chapter 16.
+- `vardax` — variational DA sibling library (OI / 3DVar / 4DVar);
+  `filterax` provides its ensemble-posterior bridge.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,29 @@ plugins:
 
 nav:
   - Home: index.md
+  - Mathematical Reference:
+      - Foundation:
+          - 1. Problem Setting: math/01_problem_setting.md
+          - 2. Ensemble Representation: math/02_ensemble_representation.md
+          - 3. Observation Model: math/03_observation_model.md
+      - Analysis Methods:
+          - 4. Kalman Update & Ensemble Gain: math/04_kalman_update.md
+          - 5. Stochastic EnKF: math/05_stochastic_enkf.md
+          - 6. ETKF: math/06_etkf.md
+          - 7. EnSRF & ESTKF: math/07_ensrf_estkf.md
+          - 8. LETKF: math/08_letkf.md
+          - 9. Ensemble Kalman Processes: math/09_ensemble_kalman_processes.md
+          - 10. Ensemble Smoothers: math/10_smoothers.md
+      - Cross-cutting:
+          - 11. Localization: math/11_localization.md
+          - 12. Inflation: math/12_inflation.md
+          - 13. Diagnostics & Likelihood: math/13_diagnostics.md
+          - 14. Differentiable Assimilation: math/14_differentiable.md
+          - 15. Latent-Space Ensemble DA: math/15_latent_da.md
+          - 16. The Assimilation Cycle: math/16_assimilation_cycle.md
+      - Reference:
+          - Notation: math/notation.md
+          - References: math/references.md
   - API Reference:
       - Overview: api/index.md
       - Protocols & Types: api/protocols.md


### PR DESCRIPTION
## Summary

Adds a vardax-style **Mathematical Reference** for filterax — 16 numbered chapters plus notation and references under `docs/math/`, wired into the nav between Home and the API Reference. Same template as vardax's: prose + arithmatex `$$` display math + an executed "Implementation in filterax" code block + cross-chapter/API links + per-chapter references.

### Foundation (1–3)
Problem setting (Bayes filter → Gaussian/ensemble approximation, divergence failure modes), ensemble representation (rows-as-members convention, Bessel correction, rank ≤ N_e−1 and its consequences, low-rank covariance via gaussx `LowRankUpdate`), observation model (implicit linearisation via Y′, structured R, perturbed observations).

### Analysis Methods (4–10)
- Kalman update & ensemble gain, with the Woodbury identity and the O(N_e²N_y + N_e³) vs O(N_y³) cost argument quoted from the gain docstring.
- Stochastic EnKF, including the Burgers et al. (1998) derivation of why observation perturbations are required.
- ETKF — proof sketch that the symmetric square root is the unique mean-preserving PSD transform, a dedicated differentiability section on the rank-N_y QR + small-eigh spectrum (why filterax doesn't delegate to `gaussx.etkf_transform`), and the Livings rotation variant.
- EnSRF / serial EnSRF / ESTKF with a square-root-family selection table.
- LETKF (per-point weights, B-loc vs R-loc, cost analysis).
- Ensemble Kalman processes (EKI/EKS/UKI, schedulers, the L1/L2/optax layering).
- Ensemble smoothers (EnKS, RTS, square-root, fixed-lag, IES).

### Cross-cutting (11–16)
Localization (Schur-product PSD argument, Gaspari-Cohn piecewise polynomial, adaptive masking), inflation (multiplicative/RTPS/RTPP/additive/adaptive/Ledoit-Wolf), diagnostics & likelihood (χ², rank histograms, CRPS, Desroziers, DFS), differentiable assimilation (scan + checkpointing, the eigh-NaN trap, ROAD-EnKF), latent-space ensemble DA, and the assimilation cycle (L1/L2 layering + pipekit-cycle protocols and adapters).

### Reference
`notation.md` — one canonical symbol table enforced across all chapters; `references.md` — ~49 entries grouped by chapter, matching the citations already present in the docstrings.

## Test plan
- [x] All 12 runnable "Implementation in filterax" code blocks executed against the real API; printed outputs pasted verbatim (the single pipekit wiring example is explicitly marked illustrative — pipekit is not a dependency)
- [x] `mkdocs build` — warning-free for every `math/` page (remaining CHANGELOG/design_docs warnings predate this PR)
- [x] Built HTML inspected: MathJax `arithmatex` spans render (50+ per chapter spot-checked), API cross-links resolve
- [x] Docs-only change — no src/tests touched; docstring gates unaffected

https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd

---
_Generated by [Claude Code](https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd)_